### PR TITLE
Apply token alpha and tint to swarms

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+	"printWidth": 120,
+	"tabWidth": 4,
+	"useTabs": true,
+	"semi": true,
+	"trailingComma": "none"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"editor.formatOnSave": true,
+	"[javascript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	}
+}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install by searching for *swarm* in the module browsing tool or manually using t
 ## Useage
 
 Right click any token (or an actors prototype token) and bring up the token config. 
-- ![image](https://user-images.githubusercontent.com/8543541/185505929-485c7db0-23fe-4573-ae92-13476e6efde5.png)
+![image](https://user-images.githubusercontent.com/8543541/185505929-485c7db0-23fe-4573-ae92-13476e6efde5.png)
 - Enable your swarm by checking the box **Swarm**
 - Check the **over** box to have your swarm fly over other tokens/players or leave it unchecked for under. Bats and crows fly over, whereas spiders under.
 - **Count** is the number of critters in your swarm
@@ -19,7 +19,7 @@ Right click any token (or an actors prototype token) and bring up the token conf
 
 
 On the next tab: *Appearance*
- - ![image](https://user-images.githubusercontent.com/8543541/184982250-82de10ae-39c3-4161-8f8a-306b548eebaf.png)
+![image](https://user-images.githubusercontent.com/8543541/184982250-82de10ae-39c3-4161-8f8a-306b548eebaf.png)
  - If you are modifying a prototype token, you can enter a wildcard pattern as your image. If enabled as well, your swarm will draw randomly from the wildcard token images.
  - Modify the **Scale** to reduce or increase the size of the individual critters.
  - Change the dimensions to create a larger area where the bugs crawl.

--- a/module.json
+++ b/module.json
@@ -1,43 +1,41 @@
 {
-  "id": "swarm",
-  "title": "Swarms",
-  "description": "Animate swarms.",
-  "version": "10.0.3",
-  "authors": [
-    {
-      "name": "o_Ove",
-      "discord": "Ove#4315",
-      "flags": {}
-    }
-  ],
-  "esmodules": [
-    "script/swarm.mjs"
-  ],
-  "url": "https://github.com/strongpauly/swarm",
-  "download": "https://github.com/strongpauly/swarm/archive/development.zip",
-  "manifest": "https://raw.githubusercontent.com/strongpauly/swarm/development/module.json",
-  "languages": [
-    {
-      "lang": "en",
-      "name": "English",
-      "path": "lang/en.json",
-      "flags": {}
-    }
-  ],
-  "socket": true,
-  "relationships": {
-    "requires": [
-      {
-        "id": "socketlib",
-        "type": "module",
-        "compatibility": {}
-      }
-    ]
-  },
-  "license": "LICENSE",
-  "readme": "README.md",
-  "compatibility": {
-    "minimum": "10",
-    "verified": "10"
-  }
+	"id": "swarm",
+	"title": "Swarms",
+	"description": "Animate swarms.",
+	"version": "10.0.3",
+	"authors": [
+		{
+			"name": "o_Ove",
+			"discord": "Ove#4315",
+			"flags": {}
+		}
+	],
+	"esmodules": ["script/swarm.mjs"],
+	"url": "https://github.com/strongpauly/swarm",
+	"download": "https://github.com/strongpauly/swarm/archive/development.zip",
+	"manifest": "https://raw.githubusercontent.com/strongpauly/swarm/development/module.json",
+	"languages": [
+		{
+			"lang": "en",
+			"name": "English",
+			"path": "lang/en.json",
+			"flags": {}
+		}
+	],
+	"socket": true,
+	"relationships": {
+		"requires": [
+			{
+				"id": "socketlib",
+				"type": "module",
+				"compatibility": {}
+			}
+		]
+	},
+	"license": "LICENSE",
+	"readme": "README.md",
+	"compatibility": {
+		"minimum": "10",
+		"verified": "10"
+	}
 }

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
 	"id": "swarm",
 	"title": "Swarms",
 	"description": "Animate swarms.",
-	"version": "10.0.3",
+	"version": "11.0.0",
 	"authors": [
 		{
 			"name": "o_Ove",
@@ -11,9 +11,9 @@
 		}
 	],
 	"esmodules": ["script/swarm.mjs"],
-	"url": "https://github.com/strongpauly/swarm",
-	"download": "https://github.com/strongpauly/swarm/archive/development.zip",
-	"manifest": "https://raw.githubusercontent.com/strongpauly/swarm/development/module.json",
+	"url": "https://github.com/oOve/swarm",
+	"download": "https://github.com/oOve/swarm/archive/11.0.0.zip",
+	"manifest": "https://github.com/oOve/swarm/releases/latest/download/module.json",
 	"languages": [
 		{
 			"lang": "en",
@@ -36,6 +36,6 @@
 	"readme": "README.md",
 	"compatibility": {
 		"minimum": "10",
-		"verified": "10"
+		"verified": "11"
 	}
 }

--- a/module.json
+++ b/module.json
@@ -13,9 +13,9 @@
   "esmodules": [
     "script/swarm.mjs"
   ],
-  "url": "https://github.com/oOve/swarm",
-  "download": "https://github.com/oOve/swarm/archive/10.0.3.zip",
-  "manifest": "https://github.com/oOve/swarm/releases/latest/download/module.json",
+  "url": "https://github.com/strongpauly/swarm",
+  "download": "https://github.com/strongpauly/swarm/archive/development.zip",
+  "manifest": "https://raw.githubusercontent.com/strongpauly/swarm/development/module.json",
   "languages": [
     {
       "lang": "en",

--- a/script/swarm.mjs
+++ b/script/swarm.mjs
@@ -66,7 +66,6 @@ function getHealthEstimate(token){
     case 'pf1':
     case 'pf2e':
     case 'dnd5e':
-      return token.actor.data.data.attributes.hp.value / token.actor.data.data.attributes.hp.max;
     case 'D35E':
       return token.actor.system.attributes.hp.value / token.actor.system.attributes.hp.max;
     default:
@@ -236,7 +235,7 @@ export default class Swarm{
         }
 
         let currentHPPercent = this.calculateHPPercent();
-                if (currentHPPercent !== this.currentHPPercent) {
+        if (currentHPPercent !== this.currentHPPercent) {
             this.currentHPPercent = currentHPPercent;
             this.number = this.determineVisibleSprites(currentHPPercent, this.maxSprites);
             // Adjust visibility based on the number of "surviving" sprites
@@ -462,8 +461,6 @@ Hooks.on('updateToken', (token, change, options, user_id)=>{
         hideSwarmOnToken(token, change.hidden);
     }
     
-
-    
 });
 
 
@@ -495,17 +492,28 @@ Hooks.on('createToken', (token, options, user_id)=>{
     createSwarmOnToken(token.object);
   }
 });
+
+const getSwarmingTokens = () => canvas.tokens.placeables.filter((t)=>!!t.document.getFlag(MOD_NAME,SWARM_FLAG)) 
  
 Hooks.on("canvasReady", ()=> {
     // Scene loaded.
-    let swarm = canvas.tokens.placeables.filter( (t)=>{return t.document.getFlag(MOD_NAME,SWARM_FLAG);} ) 
-    //console.error("canvasReady",swarm);
-    for (let s of swarm){
+    for (let s of getSwarmingTokens()){
         createSwarmOnToken(s);
     }
 });
 
- 
+Hooks.on('sightRefresh', (canvasVisibility) => {
+  if(canvasVisibility.tokenVision) {
+    const swarmedTokens = getSwarmingTokens();
+    for(let t of swarmedTokens) {
+      if(t.isVisible && !SWARMS[t.id]) {
+        createSwarmOnToken(t);
+      } else if(!t.isVisible && SWARMS[t.id]) {
+        deleteSwarmOnToken(t);
+      }
+    }
+  }
+})
  
  // Settings:
  Hooks.once("init", () => {

--- a/script/swarm.mjs
+++ b/script/swarm.mjs
@@ -170,9 +170,9 @@ export default class Swarm {
 		const use_random_image = this.token.actor.prototypeToken.randomImg;
 		const hidden = this.document.hidden;
 
-		const images = [];
+		let images = [];
 		if (use_random_image) {
-			images = await swarm_socket.executeAsGM("wildcards", token.id);
+			images = await swarm_socket.executeAsGM("wildcards", this.token.id);
 		} else {
 			images.push(this.document.texture.src);
 		}

--- a/script/swarm.mjs
+++ b/script/swarm.mjs
@@ -11,7 +11,7 @@
  ░                 ░              
  */
 const MOD_NAME = "swarm";
-const SWARM_FLAG = "isSwarm"; 
+const SWARM_FLAG = "isSwarm";
 const SWARM_SIZE_FLAG = "swarmSize";
 const SWARM_SPEED_FLAG = "swarmSpeed";
 const SWARM_IMAGE_FLAG = "swarmImage";
@@ -23,7 +23,14 @@ const ANIM_TYPE_SPIRAL = "spiral";
 const ANIM_TYPE_SKITTER = "skitter";
 const ANIM_TYPE_STOPNMOVE = "move_stop_move";
 const ANIM_TYPE_FORMATION_SQUARE = "formation";
-const ANIM_TYPES = [ANIM_TYPE_CIRCULAR, ANIM_TYPE_RAND_SQUARE, ANIM_TYPE_SPIRAL,ANIM_TYPE_SKITTER, ANIM_TYPE_STOPNMOVE, ANIM_TYPE_FORMATION_SQUARE];
+const ANIM_TYPES = [
+	ANIM_TYPE_CIRCULAR,
+	ANIM_TYPE_RAND_SQUARE,
+	ANIM_TYPE_SPIRAL,
+	ANIM_TYPE_SKITTER,
+	ANIM_TYPE_STOPNMOVE,
+	ANIM_TYPE_FORMATION_SQUARE
+];
 
 const OVER_FLAG = "swarmOverPlayers";
 const SETTING_HP_REDUCE = "reduceSwarmWithHP";
@@ -35,845 +42,833 @@ const SETTING_MIGRATED_TO = "migratedTo";
 const theta = 0.01;
 const SIGMA = 5;
 const GAMMA = 1000;
-import * as utils from "./utils.mjs"
+import * as utils from "./utils.mjs";
 
-function Lang(k){
-    return game.i18n.localize("SWARM."+k);
+function Lang(k) {
+	return game.i18n.localize("SWARM." + k);
 }
-
 
 let swarm_socket;
 Hooks.once("socketlib.ready", () => {
-  // socketlib is activated, lets register our function moveAsGM
-	swarm_socket = socketlib.registerModule(MOD_NAME);	
+	// socketlib is activated, lets register our function moveAsGM
+	swarm_socket = socketlib.registerModule(MOD_NAME);
 	swarm_socket.register("wildcards", wildcards);
 });
 
-async function wildcards(token_id){
-  let tk = canvas.tokens.get(token_id);
-  if(tk){
-    return await tk.actor.getTokenImages();
-  }
-  else{
-    return [];
-  }
+async function wildcards(token_id) {
+	let tk = canvas.tokens.get(token_id);
+	if (tk) {
+		return await tk.actor.getTokenImages();
+	} else {
+		return [];
+	}
 }
 
-function getHealthEstimate(token){
-  let reduceHP = game.settings.get(MOD_NAME, SETTING_HP_REDUCE);
-  if (!reduceHP) return 1;  // always return 100% health
+function getHealthEstimate(token) {
+	let reduceHP = game.settings.get(MOD_NAME, SETTING_HP_REDUCE);
+	if (!reduceHP) return 1; // always return 100% health
 
-  switch (game.system.id){
-    case 'pf1':
-    case 'pf2e':
-    case 'dnd5e':
-    case 'D35E':
-      return token.actor.system.attributes.hp.value / token.actor.system.attributes.hp.max;
-    default:
-      let hpValue = Object.byString(token, game.settings.get(MOD_NAME, SETTING_HP_REDUCE_ATTRIBUTE_VALUE));
-      let hpMax = Object.byString(token, game.settings.get(MOD_NAME, SETTING_HP_REDUCE_ATTRIBUTE_MAX));
-      if (hpValue && hpMax) {
-        return hpValue / hpMax;
-      } else {
-        console.warn("No health estimate implemented for system", game.system.id);
-      }
-  }
+	switch (game.system.id) {
+		case "pf1":
+		case "pf2e":
+		case "dnd5e":
+		case "D35E":
+			return token.actor.system.attributes.hp.value / token.actor.system.attributes.hp.max;
+		default:
+			let hpValue = Object.byString(token, game.settings.get(MOD_NAME, SETTING_HP_REDUCE_ATTRIBUTE_VALUE));
+			let hpMax = Object.byString(token, game.settings.get(MOD_NAME, SETTING_HP_REDUCE_ATTRIBUTE_MAX));
+			if (hpValue && hpMax) {
+				return hpValue / hpMax;
+			} else {
+				console.warn("No health estimate implemented for system", game.system.id);
+			}
+	}
 }
 
- 
 const SWARMS = {};
 // TODO: Remove debug accessor
 window.SWARMS = SWARMS;
 
 export default class Swarm {
-    constructor( token, document = token.document ){
-        const number = document.getFlag(MOD_NAME, SWARM_SIZE_FLAG)
-        this.t = 0;
-        this.token = token;
-        this.document = document
-        this.currentHPPercent = this.calculateHPPercent();  // Calculate current HP percent
-        this.number = this.determineVisibleSprites(this.currentHPPercent, number);  // Determine initial number of visible sprites
-        this.maxSprites = number;  // Store the maximum number of sprites
-        this.sprites= [];
-        this.dest   = [];
-        this.speeds = [];
-        this.ofsets = [];
-        this.waiting= [];
-        this.layer = new PIXI.Container();
+	constructor(token, document = token.document) {
+		const number = document.getFlag(MOD_NAME, SWARM_SIZE_FLAG);
+		this.t = 0;
+		this.token = token;
+		this.document = document;
+		this.currentHPPercent = this.calculateHPPercent(); // Calculate current HP percent
+		this.number = this.determineVisibleSprites(this.currentHPPercent, number); // Determine initial number of visible sprites
+		this.maxSprites = number; // Store the maximum number of sprites
+		this.sprites = [];
+		this.dest = [];
+		this.speeds = [];
+		this.ofsets = [];
+		this.waiting = [];
+		this.layer = new PIXI.Container();
 
-        // this.randomRotation = true;        
-        this.faded  = document.hidden;
-        this.visible= (this.faded) ? 0 : this.number;
-        this.spriteAlpha = document.alpha;
+		// this.randomRotation = true;
+		this.faded = document.hidden;
+		this.visible = this.faded ? 0 : this.number;
+		this.spriteAlpha = document.alpha;
 
-        const swarm = this;
+		const swarm = this;
 
-        Object.defineProperty(document, "alpha", {
-          get() {
-            return 0;
-          },
-          set(v) {
-            if(!document.hidden) {
-              swarm.spriteAlpha = v
-            }
-          },
-          configurable: true,
-          enumerable: true,
-        });
-        token.alpha = 0;
+		Object.defineProperty(document, "alpha", {
+			get() {
+				return 0;
+			},
+			set(v) {
+				if (!document.hidden) {
+					swarm.spriteAlpha = v;
+				}
+			},
+			configurable: true,
+			enumerable: true
+		});
+		token.alpha = 0;
 
-        this.layer.elevation = (document.getFlag(MOD_NAME, OVER_FLAG)?10000:0);
-        this.layer.sort = 120; // Above tiles at 100
-        this.layer.alpha = token.isVisible ? this.spriteAlpha : 0;
-        canvas.primary.addChild(this.layer);
-                
-        this.created = false;
-        
-        this.tick = new PIXI.Ticker();
-        const anim = document.getFlag(MOD_NAME, ANIM_TYPE_FLAG);
-        this.set_destinations = this.circular;
-        switch(anim){
-          case ANIM_TYPE_CIRCULAR:
-            this.set_destinations = this.circular;
-            break;
-          case ANIM_TYPE_RAND_SQUARE:
-            this.set_destinations = this.randSquare;
-            break;
-          case ANIM_TYPE_SPIRAL:
-            this.set_destinations = this.spiral;
-            break;
-          case ANIM_TYPE_SKITTER:
-            this.set_destinations = this.skitter;
-            break;
-          case ANIM_TYPE_STOPNMOVE:
-            this.set_destinations = this.stopMoveStop;
-            break;
-          case ANIM_TYPE_FORMATION_SQUARE:
-            this.set_destinations = this.formSquare;
-            // this.randomRotation = false;
-            break;
-        }
-        this.tick.add( this.anim.bind(this) );
-        this.tick.start();
-        Hooks.call('createSwarm', this)
-    }
-    
-    async createSprites( number ){
-        const use_random_image = this.token.actor.prototypeToken.randomImg;
-        const hidden = this.document.hidden;
+		this.layer.elevation = document.getFlag(MOD_NAME, OVER_FLAG) ? 10000 : 0;
+		this.layer.sort = 120; // Above tiles at 100
+		this.layer.alpha = token.isVisible ? this.spriteAlpha : 0;
+		canvas.primary.addChild(this.layer);
 
-        const images = [];
-        if (use_random_image){            
-            images = await swarm_socket.executeAsGM("wildcards",token.id);                
-        }else{
-          images.push(this.document.texture.src);
-        }
+		this.created = false;
 
-        for(let i=0;i<number;++i){
-            // waiting times, only used for stop-move
-            this.waiting.push(0);
-            // Random offset
-            this.ofsets.push(Math.random()*97);
-            // Pick an image from the list at random
-            let img = images[Math.floor(Math.random()*images.length)];
-            let s = PIXI.Sprite.from(img);
-            s.anchor.set(.5);
-            
-            // Sprites initial position, a random position within this tokens area
-            s.x = this.token.x + Math.random() * this.token.w;
-            s.y = this.token.y + Math.random() * this.token.h;
-            // Hidden initially?
-            s.alpha = (hidden)?0:1;
+		this.tick = new PIXI.Ticker();
+		const anim = document.getFlag(MOD_NAME, ANIM_TYPE_FLAG);
+		this.set_destinations = this.circular;
+		switch (anim) {
+			case ANIM_TYPE_CIRCULAR:
+				this.set_destinations = this.circular;
+				break;
+			case ANIM_TYPE_RAND_SQUARE:
+				this.set_destinations = this.randSquare;
+				break;
+			case ANIM_TYPE_SPIRAL:
+				this.set_destinations = this.spiral;
+				break;
+			case ANIM_TYPE_SKITTER:
+				this.set_destinations = this.skitter;
+				break;
+			case ANIM_TYPE_STOPNMOVE:
+				this.set_destinations = this.stopMoveStop;
+				break;
+			case ANIM_TYPE_FORMATION_SQUARE:
+				this.set_destinations = this.formSquare;
+				// this.randomRotation = false;
+				break;
+		}
+		this.tick.add(this.anim.bind(this));
+		this.tick.start();
+		Hooks.call("createSwarm", this);
+	}
 
-            // A callback to start the video
-            const start = () => {       
-                // Check if the texture selected is a video, and potentially start it
-                const src = s.texture.baseTexture.resource.source;
-                src.loop = true;
-                src.muted = true; // Autostarting videos must explicitly be muted (chrome restriction)
-                if (src.play) src.play();
-            };
-            if (s.texture.baseTexture.valid){
-              start();
-            } else {
-              s.texture.baseTexture.on('loaded', start);
-            }            
-            // Set the initial destination to its initial position
-            this.dest.push({x:s.x, y:s.y});
-            this.sprites.push(s);
-            let sf = this.document.getFlag(MOD_NAME, SWARM_SPEED_FLAG);
-            if (sf===undefined) sf = 1;
-            // Add 50% of the speed as variability on each sprites speed
-            this.speeds.push( sf*.5 + sf * Math.random()*0.5 )
-            // Add this sprite to the correct layer
-            this.layer.addChild(s);
-        }
-    }
+	async createSprites(number) {
+		const use_random_image = this.token.actor.prototypeToken.randomImg;
+		const hidden = this.document.hidden;
 
-    calculateHPPercent() {
-        return getHealthEstimate(this.token);
-    }
+		const images = [];
+		if (use_random_image) {
+			images = await swarm_socket.executeAsGM("wildcards", token.id);
+		} else {
+			images.push(this.document.texture.src);
+		}
 
-    determineVisibleSprites(hpPercent, maxNumber) {
-        // No sprites when hp zero
-        if (hpPercent <= 0) return 0;
-        const minSprites = 1;
-        return Math.max(minSprites, Math.round(hpPercent * maxNumber));
-    }
+		for (let i = 0; i < number; ++i) {
+			// waiting times, only used for stop-move
+			this.waiting.push(0);
+			// Random offset
+			this.ofsets.push(Math.random() * 97);
+			// Pick an image from the list at random
+			let img = images[Math.floor(Math.random() * images.length)];
+			let s = PIXI.Sprite.from(img);
+			s.anchor.set(0.5);
 
-    determineStep(ms) {
-      const fd = game.settings.get(MOD_NAME, SETTING_FADE_TIME);
-      const count = Math.abs(this.visible - this.number);
-      // step, corresponding to the module setting "fade time", also, prevent division by zero
-      return (fd==0)?(count):(ms*count)/(fd*1000);
-    }
+			// Sprites initial position, a random position within this tokens area
+			s.x = this.token.x + Math.random() * this.token.w;
+			s.y = this.token.y + Math.random() * this.token.h;
+			// Hidden initially?
+			s.alpha = hidden ? 0 : 1;
 
-    /**
-     * The main animation callback for this swarm
-     * @param {Number} t Time fraction of the current fps
-     */
-    anim(t){
-        if (!this.created){
-          this.createSprites(this.maxSprites);  // Use maxSprites instead of number
-        }
+			// A callback to start the video
+			const start = () => {
+				// Check if the texture selected is a video, and potentially start it
+				const src = s.texture.baseTexture.resource.source;
+				src.loop = true;
+				src.muted = true; // Autostarting videos must explicitly be muted (chrome restriction)
+				if (src.play) src.play();
+			};
+			if (s.texture.baseTexture.valid) {
+				start();
+			} else {
+				s.texture.baseTexture.on("loaded", start);
+			}
+			// Set the initial destination to its initial position
+			this.dest.push({ x: s.x, y: s.y });
+			this.sprites.push(s);
+			let sf = this.document.getFlag(MOD_NAME, SWARM_SPEED_FLAG);
+			if (sf === undefined) sf = 1;
+			// Add 50% of the speed as variability on each sprites speed
+			this.speeds.push(sf * 0.5 + sf * Math.random() * 0.5);
+			// Add this sprite to the correct layer
+			this.layer.addChild(s);
+		}
+	}
 
-        t = Math.min(t,2.0);// Cap frame skip to two frames
-        // Milliseconds elapsed, as calculated using the "time" fraction and current fps
-        const ms = t*1000*(1.0/this.tick.FPS);
-       
+	calculateHPPercent() {
+		return getHealthEstimate(this.token);
+	}
 
-        const getScale = s => {
-          // Get the largest dimension, and scale around that
-          const smax = Math.max(s.texture.width, s.texture.height);
-          const x = this.document.texture.scaleX * canvas.grid.size / smax;
-          const y = this.document.texture.scaleY * canvas.grid.size / smax;
-          return {x, y}
-        }
+	determineVisibleSprites(hpPercent, maxNumber) {
+		// No sprites when hp zero
+		if (hpPercent <= 0) return 0;
+		const minSprites = 1;
+		return Math.max(minSprites, Math.round(hpPercent * maxNumber));
+	}
 
-        let updateSprites =
-          this.tint != this.document.texture.tint;
+	determineStep(ms) {
+		const fd = game.settings.get(MOD_NAME, SETTING_FADE_TIME);
+		const count = Math.abs(this.visible - this.number);
+		// step, corresponding to the module setting "fade time", also, prevent division by zero
+		return fd == 0 ? count : (ms * count) / (fd * 1000);
+	}
 
-        const currentHPPercent = this.calculateHPPercent();
-        if (currentHPPercent !== this.currentHPPercent || !this.created) {
-          this.currentHPPercent = currentHPPercent;
-          this.number = this.determineVisibleSprites(currentHPPercent, this.maxSprites);
-          this.step = this.determineStep(ms)
-          updateSprites = true;
-        }
+	/**
+	 * The main animation callback for this swarm
+	 * @param {Number} t Time fraction of the current fps
+	 */
+	anim(t) {
+		if (!this.created) {
+			this.createSprites(this.maxSprites); // Use maxSprites instead of number
+		}
 
-        if(this.step === null) {
-          this.step = this.determineStep(ms)
-        }
+		t = Math.min(t, 2.0); // Cap frame skip to two frames
+		// Milliseconds elapsed, as calculated using the "time" fraction and current fps
+		const ms = t * 1000 * (1.0 / this.tick.FPS);
 
-        if (Math.round(this.visible) !== this.number) {
-          updateSprites = true;
-          if (this.visible > this.number) {
-            this.visible -= this.step;
-            if (this.visible < this.number) {
-              this.visible = this.number;
-            }
-          } else {
-            this.visible += this.step;
-            if (this.visible > this.number) {
-              this.visible = this.number;
-            }
-          }
-        }
+		const getScale = (s) => {
+			// Get the largest dimension, and scale around that
+			const smax = Math.max(s.texture.width, s.texture.height);
+			const x = (this.document.texture.scaleX * canvas.grid.size) / smax;
+			const y = (this.document.texture.scaleY * canvas.grid.size) / smax;
+			return { x, y };
+		};
 
-        if(!updateSprites && this.sprites.length) {
-          if (typeof this.scale === 'undefined') {
-            updateSprites = true;
-          } else {
-            const scale = getScale(this.sprites[0]);
-            updateSprites = this.scale.x !== scale.x || this.scale.y !== scale.y;
-          }
-        }
+		let updateSprites = this.tint != this.document.texture.tint;
 
-        if(updateSprites) {
-          const remaining = Math.round(this.maxSprites - this.visible);
-          this.sprites.forEach((s,i) => {
-            s.alpha = i >= remaining ? this.spriteAlpha : this.faded && game.user.isGM ? this.spriteAlpha * 0.2: 0;
-            this.scale = getScale(s);
-            s.scale.x = this.scale.x;
-            s.scale.y = this.scale.y;
-            if(this.document.texture.tint) {
-              this.tint = s.tint = this.document.texture.tint;
-            }
-          });
-        }
+		const currentHPPercent = this.calculateHPPercent();
+		if (currentHPPercent !== this.currentHPPercent || !this.created) {
+			this.currentHPPercent = currentHPPercent;
+			this.number = this.determineVisibleSprites(currentHPPercent, this.maxSprites);
+			this.step = this.determineStep(ms);
+			updateSprites = true;
+		}
 
-        // Calling the animation specific method, set_destination
-        this.set_destinations(ms);
-        // Calling the generic move method
-        this.move(ms);
-        this.created = true;
-        // Keep rotation
-        // if (!this.randomRotation){
-        //     this.rotation(this.token.document.rotation);
-        // }
-    }
+		if (this.step === null) {
+			this.step = this.determineStep(ms);
+		}
 
-    hide(hidden){
-        this.faded = hidden;
-        // Clear step to be recalcuated on next tick
-        this.step = null;
-        if(hidden) {
-          this.number = 0;
-        } else {
-          this.number = this.determineVisibleSprites(this.currentHPPercent, this.maxSprites)
-        }
-    }
+		if (Math.round(this.visible) !== this.number) {
+			updateSprites = true;
+			if (this.visible > this.number) {
+				this.visible -= this.step;
+				if (this.visible < this.number) {
+					this.visible = this.number;
+				}
+			} else {
+				this.visible += this.step;
+				if (this.visible > this.number) {
+					this.visible = this.number;
+				}
+			}
+		}
 
-    // TODO: HP interaction    
-    kill(percentage){
-    }
-      
-    destroy(){
-        Hooks.call('preDestroySwarm', this)
-        for (let s of this.sprites){
-            s.destroy();
-        }
-        this.tick.destroy();        
-        this.layer.destroy();
-        Object.defineProperty(this.document, 'alpha', {
-          value: this.spriteAlpha, 
-          configurable: true,
-          enumerable: true,
-          writable: true
-        })
-        Hooks.call('destroySwarm', this)
-    }
+		if (!updateSprites && this.sprites.length) {
+			if (typeof this.scale === "undefined") {
+				updateSprites = true;
+			} else {
+				const scale = getScale(this.sprites[0]);
+				updateSprites = this.scale.x !== scale.x || this.scale.y !== scale.y;
+			}
+			if (!updateSprites) {
+				updateSprites = this.sprites[0].spriteAlpha !== this.spriteAlpha;
+			}
+		}
 
-    skitter(ms) {
-        this.stopMoveStop(ms);
+		if (updateSprites) {
+			const remaining = Math.round(this.maxSprites - this.visible);
+			this.sprites.forEach((s, i) => {
+				s.alpha = i >= remaining ? this.spriteAlpha : this.faded && game.user.isGM ? this.spriteAlpha * 0.2 : 0;
+				s.spriteAlpha = this.spriteAlpha;
+				this.scale = getScale(s);
+				s.scale.x = this.scale.x;
+				s.scale.y = this.scale.y;
+				if (this.document.texture.tint) {
+					this.tint = s.tint = this.document.texture.tint;
+				}
+			});
+		}
 
-        let pcs = canvas.tokens.placeables.filter(t=>t.actor.hasPlayerOwner);
-        let pcp = pcs.map(t=>t.center);
-        let occ = pcs.map(t=>(.55*t.w)**2);
+		// Calling the animation specific method, set_destination
+		this.set_destinations(ms);
+		// Calling the generic move method
+		this.move(ms);
+		this.created = true;
+		// Keep rotation
+		// if (!this.randomRotation){
+		//     this.rotation(this.token.document.rotation);
+		// }
+	}
 
-        if (pcs.length>0){
-            for (let i=0; i<this.sprites.length;++i){
-                let s = this.sprites[i];
-                let sp = {x:s.x, y:s.y};
-                let dists2 = pcp.map(p=>{return (s.x-p.x)**2+ (s.y-p.y)**2});
-                let smallest = utils.argMin(dists2);
-                if (dists2[smallest]<occ[smallest]){
-                    // We are "inside" a player
-                    let out = utils.vSub(sp,pcp[smallest]);
-                    if ((out.x**2+out.y**2) > theta){
-                        let shortest_direction_out_normed = utils.vNorm(out);
-                        let distance_left_out = 0.1 + Math.sqrt(occ[smallest]) - Math.sqrt(dists2[smallest]);
-                        this.dest[i] = utils.vAdd(sp, utils.vMult(shortest_direction_out_normed, 1.5*distance_left_out));
-                    }
-                }
-            }
-        }
-    }
+	hide(hidden) {
+		this.faded = hidden;
+		// Clear step to be recalcuated on next tick
+		this.step = null;
+		if (hidden) {
+			this.number = 0;
+		} else {
+			this.number = this.determineVisibleSprites(this.currentHPPercent, this.maxSprites);
+		}
+	}
 
-    stopMoveStop(ms){
-      for (let i=0; i<this.sprites.length;++i){
-        let s = this.sprites[i];
-        let d = utils.vSub(this.dest[i], {x:s.x, y:s.y});
-        if (d.x**2+d.y**2 < SIGMA){
-          if (this.waiting[i]<=0){
-            let x = this.token.x + Math.random() * this.token.w;
-            let y = this.token.y + Math.random() * this.token.h;
-            this.dest[i] = {x:x,y:y};
-            this.waiting[i] = Math.random()*game.settings.get(MOD_NAME, SETTING_STOP_TIME)*1000;
-          }
-          else{
-            this.waiting[i]-=ms;
-          }
-        }
-      }
+	destroy() {
+		Hooks.call("preDestroySwarm", this);
+		for (let s of this.sprites) {
+			s.destroy();
+		}
+		this.tick.destroy();
+		this.layer.destroy();
+		Object.defineProperty(this.document, "alpha", {
+			value: this.spriteAlpha,
+			configurable: true,
+			enumerable: true,
+			writable: true
+		});
+		Hooks.call("destroySwarm", this);
+	}
 
-    }
+	skitter(ms) {
+		this.stopMoveStop(ms);
 
-    formSquare(ms){
-      //Calculate length and width
-      let a = Math.ceil(Math.sqrt(this.sprites.length));  //Number of rows
-      let b = Math.ceil(this.sprites.length / a);  //Vertical number
-      let c = a - (a * b - this.sprites.length);  //last row
-      let angle = this.token.document.rotation * (Math.PI / 180);
-      let center = this.token.center;
+		let pcs = canvas.tokens.placeables.filter((t) => t.actor.hasPlayerOwner);
+		let pcp = pcs.map((t) => t.center);
+		let occ = pcs.map((t) => (0.55 * t.w) ** 2);
 
-      for (let i=0; i<this.sprites.length;++i){
-        let s = this.sprites[i];
-        // Calculate the coordinate position in a square matrix
-        let x = this.token.x + (this.token.w / a) * ((i - c) % a + 0.5);
-        let y = this.token.y + (this.token.h / b) * (Math.floor((i - c) / a) + 1.5);
-        // separate treatment for the first row
-        if (c > 0 && i < c){
-            x = this.token.x + (this.token.w / c) * (i % c + 0.5);
-        }
+		if (pcs.length > 0) {
+			for (let i = 0; i < this.sprites.length; ++i) {
+				let s = this.sprites[i];
+				let sp = { x: s.x, y: s.y };
+				let dists2 = pcp.map((p) => {
+					return (s.x - p.x) ** 2 + (s.y - p.y) ** 2;
+				});
+				let smallest = utils.argMin(dists2);
+				if (dists2[smallest] < occ[smallest]) {
+					// We are "inside" a player
+					let out = utils.vSub(sp, pcp[smallest]);
+					if (out.x ** 2 + out.y ** 2 > theta) {
+						let shortest_direction_out_normed = utils.vNorm(out);
+						let distance_left_out = 0.1 + Math.sqrt(occ[smallest]) - Math.sqrt(dists2[smallest]);
+						this.dest[i] = utils.vAdd(
+							sp,
+							utils.vMult(shortest_direction_out_normed, 1.5 * distance_left_out)
+						);
+					}
+				}
+			}
+		}
+	}
 
-        //Rotate the square matrix following the token direction
-        let x3 = (x - center.x) * Math.cos(angle) - (y - center.y) * Math.sin(angle) + center.x;
-        let y3 = (x - center.x) * Math.sin(angle) + (y - center.y) * Math.cos(angle) + center.y;
-        x = x3;
-        y = y3;
+	stopMoveStop(ms) {
+		for (let i = 0; i < this.sprites.length; ++i) {
+			let s = this.sprites[i];
+			let d = utils.vSub(this.dest[i], { x: s.x, y: s.y });
+			if (d.x ** 2 + d.y ** 2 < SIGMA) {
+				if (this.waiting[i] <= 0) {
+					let x = this.token.x + Math.random() * this.token.w;
+					let y = this.token.y + Math.random() * this.token.h;
+					this.dest[i] = { x: x, y: y };
+					this.waiting[i] = Math.random() * game.settings.get(MOD_NAME, SETTING_STOP_TIME) * 1000;
+				} else {
+					this.waiting[i] -= ms;
+				}
+			}
+		}
+	}
 
-        //Turn to the direction of the token when it is close enough to where it should be in the square.
-        let d = utils.vSub({x:x,y:y}, {x:s.x, y:s.y});
-        let len = utils.vLen(d);
-        if(len<SIGMA){
-            s.rotation = angle;
-        }else{
-            this.dest[i] = {x:x,y:y};
-        }
-      }
-    }
-    
-    randSquare(ms){
-      for (let i=0; i<this.sprites.length;++i){
-        let s = this.sprites[i];
-        let d = utils.vSub(this.dest[i], {x:s.x, y:s.y});
-        let len = utils.vLen(d);
-        if (len<SIGMA || len>GAMMA){
-          let x = this.token.x + Math.random() * this.token.w;
-          let y = this.token.y + Math.random() * this.token.h;
-          this.dest[i] = {x:x,y:y};
-        }
-      }
-    }
-    spiral(ms){
-        this.t += ms/30;
-        let rx =  0.5 * this.token.w;
-        let ry =  0.5 * this.token.h;
-        for (let i=0; i<this.sprites.length;++i){
-            let t = this.speeds[i] * this.t*0.02 + this.ofsets[i];
-            let x = Math.cos(t);
-            let y = 0.4*Math.sin(t);
+	formSquare(ms) {
+		//Calculate length and width
+		let a = Math.ceil(Math.sqrt(this.sprites.length)); //Number of rows
+		let b = Math.ceil(this.sprites.length / a); //Vertical number
+		let c = a - (a * b - this.sprites.length); //last row
+		let angle = this.token.document.rotation * (Math.PI / 180);
+		let center = this.token.center;
 
-            let ci = Math.cos(t/(2*Math.E));
-            let si = Math.sin(t/(2*Math.E));
-            this.dest[i] = {x: rx*(ci*x - si*y) + this.token.center.x,
-                            y: ry*(si*x + ci*y) + this.token.center.y };
-        }
-    }
-    circular(ms){
-        this.t += ms/30;        
-        let _rx = 1 * 0.5 * this.token.w;
-        let _ry = 1 * 0.5 * this.token.h;
+		for (let i = 0; i < this.sprites.length; ++i) {
+			let s = this.sprites[i];
+			// Calculate the coordinate position in a square matrix
+			let x = this.token.x + (this.token.w / a) * (((i - c) % a) + 0.5);
+			let y = this.token.y + (this.token.h / b) * (Math.floor((i - c) / a) + 1.5);
+			// separate treatment for the first row
+			if (c > 0 && i < c) {
+				x = this.token.x + (this.token.w / c) * ((i % c) + 0.5);
+			}
 
-        for (let i=0; i<this.sprites.length;++i){
-            
-            let t = this.t * 0.02 + this.ofsets[i];
-            let rY = 1 * (0.5 + 0.5 * ( 
-                1.0 * Math.sin(    t * 0.3) + 
-                0.3 * Math.sin(2 * t + 0.8) + 
-                0.26* Math.sin(3 * t + 0.8)
-                ));
-            let x =    Math.cos(t*this.speeds[i]);
-            let y = rY*Math.sin(t*this.speeds[i]);
+			//Rotate the square matrix following the token direction
+			let x3 = (x - center.x) * Math.cos(angle) - (y - center.y) * Math.sin(angle) + center.x;
+			let y3 = (x - center.x) * Math.sin(angle) + (y - center.y) * Math.cos(angle) + center.y;
+			x = x3;
+			y = y3;
 
-            let ci = Math.cos(this.ofsets[i]);
-            let si = Math.sin(this.ofsets[i]);
-            let rx = _rx*(ci*x - si*y);
-            let ry = _ry*(si*x + ci*y);
+			//Turn to the direction of the token when it is close enough to where it should be in the square.
+			let d = utils.vSub({ x: x, y: y }, { x: s.x, y: s.y });
+			let len = utils.vLen(d);
+			if (len < SIGMA) {
+				s.rotation = angle;
+			} else {
+				this.dest[i] = { x: x, y: y };
+			}
+		}
+	}
 
-            this.dest[i] = {x:rx + this.token.center.x,
-                            y:ry + this.token.center.y};
-        }
-    }
+	randSquare(ms) {
+		for (let i = 0; i < this.sprites.length; ++i) {
+			let s = this.sprites[i];
+			let d = utils.vSub(this.dest[i], { x: s.x, y: s.y });
+			let len = utils.vLen(d);
+			if (len < SIGMA || len > GAMMA) {
+				let x = this.token.x + Math.random() * this.token.w;
+				let y = this.token.y + Math.random() * this.token.h;
+				this.dest[i] = { x: x, y: y };
+			}
+		}
+	}
+	spiral(ms) {
+		this.t += ms / 30;
+		let rx = 0.5 * this.token.w;
+		let ry = 0.5 * this.token.h;
+		for (let i = 0; i < this.sprites.length; ++i) {
+			let t = this.speeds[i] * this.t * 0.02 + this.ofsets[i];
+			let x = Math.cos(t);
+			let y = 0.4 * Math.sin(t);
 
-    move(ms){
-        for (let i=0; i<this.sprites.length;++i){
-            let s = this.sprites[i];
-            let d = utils.vSub( this.dest[i], {x:s.x, y:s.y} );
-            
-            if ((d.x**2+d.y**2) > theta){
-                let mv = utils.vNorm(d);
-                mv = utils.vMult(mv, 0.05*ms*this.speeds[i]*4);
-                if ((mv.x**2+mv.y**2)>(d.x**2+d.y**2)){mv=d;}
-                s.x += mv.x;
-                s.y += mv.y;
-                s.rotation = -Math.PI/2. + utils.vRad(d);
-            }
-        }
-    }
+			let ci = Math.cos(t / (2 * Math.E));
+			let si = Math.sin(t / (2 * Math.E));
+			this.dest[i] = {
+				x: rx * (ci * x - si * y) + this.token.center.x,
+				y: ry * (si * x + ci * y) + this.token.center.y
+			};
+		}
+	}
+	circular(ms) {
+		this.t += ms / 30;
+		let _rx = 1 * 0.5 * this.token.w;
+		let _ry = 1 * 0.5 * this.token.h;
+
+		for (let i = 0; i < this.sprites.length; ++i) {
+			let t = this.t * 0.02 + this.ofsets[i];
+			let rY =
+				1 *
+				(0.5 + 0.5 * (1.0 * Math.sin(t * 0.3) + 0.3 * Math.sin(2 * t + 0.8) + 0.26 * Math.sin(3 * t + 0.8)));
+			let x = Math.cos(t * this.speeds[i]);
+			let y = rY * Math.sin(t * this.speeds[i]);
+
+			let ci = Math.cos(this.ofsets[i]);
+			let si = Math.sin(this.ofsets[i]);
+			let rx = _rx * (ci * x - si * y);
+			let ry = _ry * (si * x + ci * y);
+
+			this.dest[i] = {
+				x: rx + this.token.center.x,
+				y: ry + this.token.center.y
+			};
+		}
+	}
+
+	move(ms) {
+		for (let i = 0; i < this.sprites.length; ++i) {
+			let s = this.sprites[i];
+			let d = utils.vSub(this.dest[i], { x: s.x, y: s.y });
+
+			if (d.x ** 2 + d.y ** 2 > theta) {
+				let mv = utils.vNorm(d);
+				mv = utils.vMult(mv, 0.05 * ms * this.speeds[i] * 4);
+				if (mv.x ** 2 + mv.y ** 2 > d.x ** 2 + d.y ** 2) {
+					mv = d;
+				}
+				s.x += mv.x;
+				s.y += mv.y;
+				s.rotation = -Math.PI / 2 + utils.vRad(d);
+			}
+		}
+	}
 }
-
 
 //Only in V10+
-Hooks.on('canvasTearDown', (a,b)=>{
-    for(let key of Object.keys(SWARMS)){
-        SWARMS[key].destroy();
-        delete SWARMS[key];
-      }
+Hooks.on("canvasTearDown", (a, b) => {
+	for (let key of Object.keys(SWARMS)) {
+		SWARMS[key].destroy();
+		delete SWARMS[key];
+	}
 });
 
-function deleteSwarmOnToken(token){
-  const swarm = SWARMS[token.id]
-    if (swarm){
-        swarm.destroy();
-        delete SWARMS[token.id];
-    }
+function deleteSwarmOnToken(token) {
+	const swarm = SWARMS[token.id];
+	if (swarm) {
+		swarm.destroy();
+		delete SWARMS[token.id];
+	}
 }
 
-function createSwarmOnToken(token, document){
-  deleteSwarmOnToken(token);
-  Hooks.call('preCreateSwarm', token, document)
-  SWARMS[token.id] = new Swarm(token, document);
+function createSwarmOnToken(token, document) {
+	deleteSwarmOnToken(token);
+	Hooks.call("preCreateSwarm", token, document);
+	SWARMS[token.id] = new Swarm(token, document);
 }
 
-function hideSwarmOnToken(token, hide){
-    if (token.id in SWARMS){
-        SWARMS[token.id].hide(hide);
-    }
+function hideSwarmOnToken(token, hide) {
+	if (token.id in SWARMS) {
+		SWARMS[token.id].hide(hide);
+	}
 }
 
 /**
- * @param {*} changes 
+ * @param {*} changes
  * @returns If any swarm related flag was in this update
  */
-const swarmNeedsRefresh = changes => {
-  if(!changes) {
-    return false;
-  }
-  if (changes.flags?.[MOD_NAME]) {
-    return true;
-  }
-  if (typeof changes.alpha === "number") {
-    return true;
-  }
-  if (changes.texture) {
-    return true;
-  }
-  return false;
-}
+const swarmNeedsRefresh = (changes) => {
+	if (!changes) {
+		return false;
+	}
+	if (changes.flags?.[MOD_NAME]) {
+		return true;
+	}
+	if (typeof changes.alpha === "number") {
+		return true;
+	}
+	if (changes.texture) {
+		return true;
+	}
+	return false;
+};
 
-Hooks.on('preUpdateToken', (document, changes) => {
-  if (swarmNeedsRefresh(changes)) {   
-    deleteSwarmOnToken(document);
-  }
-})
-
-Hooks.on('updateToken', (document, changes) => {
-    if(document.flags?.[MOD_NAME]?.[SWARM_FLAG]) {
-      // if (swarmNeedsRefresh(changes)) {
-      //     createSwarmOnToken(canvas.tokens.get(document.id));
-      // }
-      if (changes.hidden != undefined){
-          hideSwarmOnToken(document, changes.hidden);
-      }
-    }
+Hooks.on("preUpdateToken", (document, changes) => {
+	if (swarmNeedsRefresh(changes)) {
+		deleteSwarmOnToken(document);
+	}
 });
 
-Hooks.on('renderTokenConfig', (renderConfig) => {
-  const document = renderConfig.token;
-  const onDrawToken = (token) => {
-    if(token.document.id === document.id) {
-      deleteSwarmOnToken(token);
-      if(token.document.flags?.[MOD_NAME]?.[SWARM_FLAG]) {
-          createSwarmOnToken(token);
-      }
-    }
-  }
-  Hooks.on('drawToken', onDrawToken)
-  Hooks.once('closeTokenConfig', (closeConfig) => {
-    if(closeConfig.token.id === document.id) {
-      Hooks.off('drawToken', onDrawToken);
-      const {token: document} = closeConfig;
-      const token = document.object;
-      if(token) {
-        deleteSwarmOnToken(token);
-        if(document.flags?.[MOD_NAME]?.[SWARM_FLAG]) {
-            createSwarmOnToken(token, document);
-        }
-      }
-    }
-  })
+Hooks.on("updateToken", (document, changes) => {
+	if (document.flags?.[MOD_NAME]?.[SWARM_FLAG]) {
+		if (swarmNeedsRefresh(changes) && document.object) {
+			createSwarmOnToken(document.object);
+		}
+		if (changes.hidden != undefined) {
+			hideSwarmOnToken(document, changes.hidden);
+		}
+	}
 });
 
-// // TODO: Add HP interaction
-// Hooks.on('updateActor', (actor, change, options, user_id)=>{
-//     let val = change.data?.attributes?.hp?.value;
-//     if (val == undefined){
-//         val = change.system?.attributes?.hp?.value;
-//     }
-//     if (val != undefined){
-//       let tk = actor.token;
-//       let mx = actor.data.data.attributes.hp.max;
-//       let hp = 100*val/mx;
-//     }
-// });
-
+Hooks.on("renderTokenConfig", (renderConfig) => {
+	const document = renderConfig.token;
+	const onDrawToken = (token) => {
+		if (token.document.id === document.id) {
+			deleteSwarmOnToken(token);
+			if (token.document.flags?.[MOD_NAME]?.[SWARM_FLAG]) {
+				createSwarmOnToken(token);
+			}
+		}
+	};
+	Hooks.on("drawToken", onDrawToken);
+	Hooks.once("closeTokenConfig", (closeConfig) => {
+		if (closeConfig.token.id === document.id) {
+			Hooks.off("drawToken", onDrawToken);
+			const { token: document } = closeConfig;
+			const token = document.object;
+			if (token) {
+				deleteSwarmOnToken(token);
+				if (document.flags?.[MOD_NAME]?.[SWARM_FLAG]) {
+					createSwarmOnToken(token, document);
+				}
+			}
+		}
+	});
+});
 
 // Delete token
-Hooks.on('deleteToken', (token, options, user_id)=>{
-  if (token.id in SWARMS){
-    SWARMS[token.id].destroy();
-    delete SWARMS[token.id];
-  }
-})
+Hooks.on("deleteToken", (token, options, user_id) => {
+	if (token.id in SWARMS) {
+		SWARMS[token.id].destroy();
+		delete SWARMS[token.id];
+	}
+});
 
-const isSwarmingToken = (t) =>!!t.document.getFlag(MOD_NAME,SWARM_FLAG);
+const isSwarmingToken = (t) => !!t.document.getFlag(MOD_NAME, SWARM_FLAG);
 const getSwarmingTokens = () => canvas.tokens.placeables.filter(isSwarmingToken);
 
 // Create token
-Hooks.on('createToken', (token, options, user_id)=>{
-  if (token.getFlag(MOD_NAME, SWARM_FLAG)===true){
-    createSwarmOnToken(token.object);
-  }
+Hooks.on("createToken", (token, options, user_id) => {
+	if (token.getFlag(MOD_NAME, SWARM_FLAG) === true) {
+		createSwarmOnToken(token.object);
+	}
 });
 
 Hooks.on("ready", async () => {
-    if(game.settings.get(MOD_NAME, SETTING_MIGRATED_TO) < 11.0) {
-     ui.notifications.notify(`Migrating to Swarms version 11.  Please don't refresh your browser.`)
-     const actors = game.actors.filter(a => a.prototypeToken.getFlag(MOD_NAME, SWARM_FLAG) && a.prototypeToken.alpha === 0);
-     if(actors.length) {
-        await Promise.all(actors.map(async actor => await actor.prototypeToken.update({alpha: 1})))
-     }
-     let tokenCount = 0;
-     await Promise.all(game.scenes.map(async scene => {
-        const tokens = scene.tokens.filter(token => token.getFlag(MOD_NAME, SWARM_FLAG) && token.alpha === 0)
-        if(tokens.length) {
-          await Promise.all(tokens.map( async token => await token.update({alpha: 1})))
-          tokenCount += tokens.length;
-        }
-     }))
-     await game.settings.set(MOD_NAME, SETTING_MIGRATED_TO, 11.0);
-     ui.notifications.notify(`Migration to Swarms version 11 complete. Updated ${actors.length} actor(s) and ${tokenCount} token(s).`);
-    }
-    // Scene loaded.
-    for (let s of getSwarmingTokens()){
-        createSwarmOnToken(s);
-    }
+	if (game.settings.get(MOD_NAME, SETTING_MIGRATED_TO) < 11.0) {
+		ui.notifications.notify(`Migrating to Swarms version 11.  Please don't refresh your browser.`);
+		const actors = game.actors.filter(
+			(a) => a.prototypeToken.getFlag(MOD_NAME, SWARM_FLAG) && a.prototypeToken.alpha === 0
+		);
+		if (actors.length) {
+			await Promise.all(actors.map(async (actor) => await actor.prototypeToken.update({ alpha: 1 })));
+		}
+		let tokenCount = 0;
+		await Promise.all(
+			game.scenes.map(async (scene) => {
+				const tokens = scene.tokens.filter((token) => token.getFlag(MOD_NAME, SWARM_FLAG) && token.alpha === 0);
+				if (tokens.length) {
+					await Promise.all(tokens.map(async (token) => await token.update({ alpha: 1 })));
+					tokenCount += tokens.length;
+				}
+			})
+		);
+		await game.settings.set(MOD_NAME, SETTING_MIGRATED_TO, 11.0);
+		ui.notifications.notify(
+			`Migration to Swarms version 11 complete. Updated ${actors.length} actor(s) and ${tokenCount} token(s).`
+		);
+	}
+	// Scene loaded.
+	for (let s of getSwarmingTokens()) {
+		createSwarmOnToken(s);
+	}
 });
 
-Hooks.on('sightRefresh', (canvasVisibility) => {
-  if(canvasVisibility.tokenVision) {
-    const swarmedTokens = getSwarmingTokens();
-    for(let t of swarmedTokens) {
-      const swarm = SWARMS[t.id];
-      if(swarm) { // Swarm might not exist if just been updated
-        swarm.layer.alpha = t.isVisible ? swarm.spriteAlpha : 0;
-      }
-    }
-  }
-})
- 
- // Settings:
- Hooks.once("init", () => {
-    game.settings.register(MOD_NAME, SETTING_HP_REDUCE, {
-        name: "Reduce swarm with HP",
-        hint: "Reduce the swarm as HP decreases, requires support for your system",
-        scope: 'world',
-        config: true,
-        type: Boolean,
-        default: false
-   });
-    game.settings.register(MOD_NAME, SETTING_HP_REDUCE_ATTRIBUTE_VALUE, {
-        name: "Attribute for Current HP",
-        hint: "System dependent path to current hp Attribute of token (token.[...])",
-        scope: 'world',
-        config: true,
-        type: String,
-        default: "actor.system.attributes.hp.value",
-   });
-    game.settings.register(MOD_NAME, SETTING_HP_REDUCE_ATTRIBUTE_MAX, {
-        name: "Attribute for Max HP",
-        hint: "System dependent path to max hp Attribute of token (token.[...])",
-        scope: 'world',
-        config: true,
-        type: String,
-        default: "actor.system.attributes.hp.max",
-   });
-    game.settings.register(MOD_NAME, SETTING_FADE_TIME, {
-        name: "Fade time",
-        hint: "How long, in seconds, the fade in/out should take",
-        scope: 'world',
-        config: true,
-        type: Number,
-        default: 2.0
-    });
-    game.settings.register(MOD_NAME, SETTING_STOP_TIME, {
-      name: "Stop time",
-      hint: "How long, in seconds, the stop in the stop move animation",
-      scope: 'world',
-      config: true,
-      type: Number,
-      default: 5.0
-  });
+Hooks.on("sightRefresh", (canvasVisibility) => {
+	if (canvasVisibility.tokenVision) {
+		const swarmedTokens = getSwarmingTokens();
+		for (let t of swarmedTokens) {
+			const swarm = SWARMS[t.id];
+			if (swarm) {
+				// Swarm might not exist if just been updated
+				swarm.layer.alpha = t.isVisible ? swarm.spriteAlpha : 0;
+			}
+		}
+	}
+});
 
-  game.settings.register(MOD_NAME, SETTING_MIGRATED_TO, {
-      name: "Migrations",
-      scope: 'world',
-      config: false,
-      type: Number,
-      default: 0
-  });
-  
- });
+// Settings:
+Hooks.once("init", () => {
+	game.settings.register(MOD_NAME, SETTING_HP_REDUCE, {
+		name: "Reduce swarm with HP",
+		hint: "Reduce the swarm as HP decreases, requires support for your system",
+		scope: "world",
+		config: true,
+		type: Boolean,
+		default: false
+	});
+	game.settings.register(MOD_NAME, SETTING_HP_REDUCE_ATTRIBUTE_VALUE, {
+		name: "Attribute for Current HP",
+		hint: "System dependent path to current hp Attribute of token (token.[...])",
+		scope: "world",
+		config: true,
+		type: String,
+		default: "actor.system.attributes.hp.value"
+	});
+	game.settings.register(MOD_NAME, SETTING_HP_REDUCE_ATTRIBUTE_MAX, {
+		name: "Attribute for Max HP",
+		hint: "System dependent path to max hp Attribute of token (token.[...])",
+		scope: "world",
+		config: true,
+		type: String,
+		default: "actor.system.attributes.hp.max"
+	});
+	game.settings.register(MOD_NAME, SETTING_FADE_TIME, {
+		name: "Fade time",
+		hint: "How long, in seconds, the fade in/out should take",
+		scope: "world",
+		config: true,
+		type: Number,
+		default: 2.0
+	});
+	game.settings.register(MOD_NAME, SETTING_STOP_TIME, {
+		name: "Stop time",
+		hint: "How long, in seconds, the stop in the stop move animation",
+		scope: "world",
+		config: true,
+		type: Number,
+		default: 5.0
+	});
 
+	game.settings.register(MOD_NAME, SETTING_MIGRATED_TO, {
+		name: "Migrations",
+		scope: "world",
+		config: false,
+		type: Number,
+		default: 0
+	});
+});
 
- /*
-  █████  █████ █████
+/*
+ █████  █████ █████
 ░░███  ░░███ ░░███ 
- ░███   ░███  ░███ 
- ░███   ░███  ░███ 
- ░███   ░███  ░███ 
- ░███   ░███  ░███ 
- ░░████████   █████
-  ░░░░░░░░   ░░░░░  */
- 
- 
-function createLabel(text){
-  const label = document.createElement('label');
-  label.textContent = text;
-  return label;
+░███   ░███  ░███ 
+░███   ░███  ░███ 
+░███   ░███  ░███ 
+░███   ░███  ░███ 
+░░████████   █████
+ ░░░░░░░░   ░░░░░  */
+
+function createLabel(text) {
+	const label = document.createElement("label");
+	label.textContent = text;
+	return label;
 }
 
-function dropDownConfig(parent, app, flag_name, title, values, default_value=null)
-{ 
-  let flags = app.token.flags;
-  if (flags === undefined) flags = app.token.data.flags;
+function dropDownConfig(parent, app, flag_name, title, values, default_value = null) {
+	let flags = app.token.flags;
+	if (flags === undefined) flags = app.token.data.flags;
 
-  let cur = flags?.[MOD_NAME]?.[flag_name];
-  //parent.append(createLabel(title));
-  const input = document.createElement('select');
-  input.name = 'flags.'+MOD_NAME+'.'+flag_name;
-  input.style.width = "50px";
-  
-  for (let o of values){
-    let opt = document.createElement('option');
-    opt.innerText = o;
-    if (cur===o) opt.classList.add('selected');
-    input.append(opt);
-  }
-  input.value = cur;
+	let cur = flags?.[MOD_NAME]?.[flag_name];
+	//parent.append(createLabel(title));
+	const input = document.createElement("select");
+	input.name = "flags." + MOD_NAME + "." + flag_name;
+	input.style.width = "50px";
 
-  parent.append(input);
+	for (let o of values) {
+		let opt = document.createElement("option");
+		opt.innerText = o;
+		if (cur === o) opt.classList.add("selected");
+		input.append(opt);
+	}
+	input.value = cur;
+
+	parent.append(input);
 }
 
+function textBoxConfig(
+	parent,
+	app,
+	flag_name,
+	title,
+	type = "number",
+	placeholder = null,
+	default_value = null,
+	step = null
+) {
+	let flags = app.token.flags;
+	if (flags === undefined) flags = app.token.data.flags;
 
+	parent.append(createLabel(title));
+	const input = document.createElement("input");
+	input.name = "flags." + MOD_NAME + "." + flag_name;
+	input.type = type;
+	if (step) input.step = step;
+	if (placeholder) input.placeholder = placeholder;
 
-function textBoxConfig(parent, app, flag_name, title, type="number",
-                       placeholder=null, default_value=null, step=null)
-{ 
-  let flags = app.token.flags;
-  if (flags === undefined) flags = app.token.data.flags;
-
-  parent.append(createLabel(title));
-  const input = document.createElement('input');
-  input.name = 'flags.'+MOD_NAME+'.'+flag_name;
-  input.type = type;  
-  if(step) input.step = step;
-  if(placeholder) input.placeholder = placeholder;
-
-  if(flags?.[MOD_NAME]?.[flag_name]){
-    input.value=flags?.[MOD_NAME]?.[flag_name];
-  }
-  else if(default_value!=null){
-    input.value = default_value;
-  }
-  parent.append(input);
+	if (flags?.[MOD_NAME]?.[flag_name]) {
+		input.value = flags?.[MOD_NAME]?.[flag_name];
+	} else if (default_value != null) {
+		input.value = default_value;
+	}
+	parent.append(input);
 }
 
- 
- function createCheckBox(app, fields, data_name, title, hint){  
-    const label = document.createElement('label');
-    label.textContent = title; 
-    const input = document.createElement("input");
-    input.name = 'flags.'+MOD_NAME+'.' + data_name;
-    input.type = "checkbox";
-    input.title = hint;
-    
-    if (app.token.getFlag(MOD_NAME, data_name)){
-      input.checked = "true";
-    }
-  
-    fields.append(label);
-    fields.append(input);
-  }
- function imageSelector( app, flag_name, title ){
-  let data_path = 'flags.'+MOD_NAME+'.'+flag_name;
-  
-  let flags = app.token.flags;
-  if (flags === undefined) flags = app.token.data.flags;
-  
-  let grp = document.createElement('div');
-  grp.classList.add('form-group');
-  let label = document.createElement('label');
-  label.innerText = title;  
-  let fields = document.createElement('div');
-  fields.classList.add('form-fields');
-  
-  const button = document.createElement("button");
-  button.classList.add("file-picker");
-  button.type = "button";
-  button.title = "Browse Files";
-  button.tabindex = "-1";
-  button.dataset.target = data_path;
-  button['data-type'] = "imagevideo";
-  button['data-target'] = data_path;
- 
-  button.onclick = app._activateFilePicker.bind(app);
-  
-  let bi = document.createElement('i');
-  bi.classList.add('fas');
-  bi.classList.add('fa-file-import');
-  bi.classList.add('fa-fw');
-  
+function createCheckBox(app, fields, data_name, title, hint) {
+	const label = document.createElement("label");
+	label.textContent = title;
+	const input = document.createElement("input");
+	input.name = "flags." + MOD_NAME + "." + data_name;
+	input.type = "checkbox";
+	input.title = hint;
 
-  const inpt = document.createElement("input");  
-  inpt.name = data_path;
-  inpt.classList.add("image");
-  inpt.type = "text";
-  inpt.title = title;
-  inpt.placeholder = "path/image.png";
-  // Insert the flags current value into the input box  
-  if (flags?.[MOD_NAME]?.[flag_name]){
-    inpt.value=flags?.[MOD_NAME]?.[flag_name];
-  }
-  
-  button.append(bi);
+	if (app.token.getFlag(MOD_NAME, data_name)) {
+		input.checked = "true";
+	}
 
-  grp.append(label);
-  grp.append(fields);
-  
-  fields.append(button);
-  fields.append(inpt);
-  return grp;
- }
-  
-  
-  // Hook into the token config render
-  Hooks.on("renderTokenConfig", (app, html) => {
-    if (!game.user.isGM) return;
-  
-    // Create a new form group
-    const formGroup = document.createElement("div");
-    formGroup.classList.add("form-group");
-    formGroup.classList.add("slim");
-  
-    // Create a label for this setting
-    const label = document.createElement("label");
-    label.textContent = "Swarm";
-    formGroup.prepend(label);
-  
-    // Create a form fields container
-    const formFields = document.createElement("div");
-    formFields.classList.add("form-fields");
-    formGroup.append(formFields);
-  
-    createCheckBox(app, formFields, SWARM_FLAG, "", '');
-    createCheckBox(app, formFields, OVER_FLAG, "Over", "Check if the swarm should be placed over players." );
-    textBoxConfig(formFields, app, SWARM_SIZE_FLAG, "Count", "number", 20, 20,1);
-    textBoxConfig(formFields, app, SWARM_SPEED_FLAG, "Speed", "number", 1.0, 1.0, 0.1);
-    dropDownConfig(formFields,app, ANIM_TYPE_FLAG, "anim", ANIM_TYPES, ANIM_TYPE_CIRCULAR);
+	fields.append(label);
+	fields.append(input);
+}
+function imageSelector(app, flag_name, title) {
+	let data_path = "flags." + MOD_NAME + "." + flag_name;
 
-    // Add the form group to the bottom of the Identity tab
-    html[0].querySelector("div[data-tab='character']").append(formGroup);
+	let flags = app.token.flags;
+	if (flags === undefined) flags = app.token.data.flags;
 
+	let grp = document.createElement("div");
+	grp.classList.add("form-group");
+	let label = document.createElement("label");
+	label.innerText = title;
+	let fields = document.createElement("div");
+	fields.classList.add("form-fields");
 
-    // Add difference swarm image
-    //const swarmImage = imageSelector(app, SWARM_IMAGE_FLAG, "Token for Swarm mobs");
-    // And add the token image selectors to the 'apperance' tab
-    //html[0].querySelector("div[data-tab='appearance']").append(swarmImage);
-  
-    // Set the apps height correctly
-    app.setPosition();
-  });
-  
+	const button = document.createElement("button");
+	button.classList.add("file-picker");
+	button.type = "button";
+	button.title = "Browse Files";
+	button.tabindex = "-1";
+	button.dataset.target = data_path;
+	button["data-type"] = "imagevideo";
+	button["data-target"] = data_path;
+
+	button.onclick = app._activateFilePicker.bind(app);
+
+	let bi = document.createElement("i");
+	bi.classList.add("fas");
+	bi.classList.add("fa-file-import");
+	bi.classList.add("fa-fw");
+
+	const inpt = document.createElement("input");
+	inpt.name = data_path;
+	inpt.classList.add("image");
+	inpt.type = "text";
+	inpt.title = title;
+	inpt.placeholder = "path/image.png";
+	// Insert the flags current value into the input box
+	if (flags?.[MOD_NAME]?.[flag_name]) {
+		inpt.value = flags?.[MOD_NAME]?.[flag_name];
+	}
+
+	button.append(bi);
+
+	grp.append(label);
+	grp.append(fields);
+
+	fields.append(button);
+	fields.append(inpt);
+	return grp;
+}
+
+// Hook into the token config render
+Hooks.on("renderTokenConfig", (app, html) => {
+	if (!game.user.isGM) return;
+
+	// Create a new form group
+	const formGroup = document.createElement("div");
+	formGroup.classList.add("form-group");
+	formGroup.classList.add("slim");
+
+	// Create a label for this setting
+	const label = document.createElement("label");
+	label.textContent = "Swarm";
+	formGroup.prepend(label);
+
+	// Create a form fields container
+	const formFields = document.createElement("div");
+	formFields.classList.add("form-fields");
+	formGroup.append(formFields);
+
+	createCheckBox(app, formFields, SWARM_FLAG, "", "");
+	createCheckBox(app, formFields, OVER_FLAG, "Over", "Check if the swarm should be placed over players.");
+	textBoxConfig(formFields, app, SWARM_SIZE_FLAG, "Count", "number", 20, 20, 1);
+	textBoxConfig(formFields, app, SWARM_SPEED_FLAG, "Speed", "number", 1.0, 1.0, 0.1);
+	dropDownConfig(formFields, app, ANIM_TYPE_FLAG, "anim", ANIM_TYPES, ANIM_TYPE_CIRCULAR);
+
+	// Add the form group to the bottom of the Identity tab
+	html[0].querySelector("div[data-tab='character']").append(formGroup);
+
+	// Add difference swarm image
+	//const swarmImage = imageSelector(app, SWARM_IMAGE_FLAG, "Token for Swarm mobs");
+	// And add the token image selectors to the 'apperance' tab
+	//html[0].querySelector("div[data-tab='appearance']").append(swarmImage);
+
+	// Set the apps height correctly
+	app.setPosition();
+});

--- a/script/swarm.mjs
+++ b/script/swarm.mjs
@@ -502,14 +502,6 @@ export default class Swarm {
 	}
 }
 
-//Only in V10+
-Hooks.on("canvasTearDown", (a, b) => {
-	for (let key of Object.keys(SWARMS)) {
-		SWARMS[key].destroy();
-		delete SWARMS[key];
-	}
-});
-
 function deleteSwarmOnToken(token) {
 	const swarm = SWARMS[token.id];
 	if (swarm) {
@@ -635,9 +627,20 @@ Hooks.on("ready", async () => {
 			`Migration to Swarms version 11 complete. Updated ${actors.length} actor(s) and ${tokenCount} token(s).`
 		);
 	}
+});
+
+Hooks.on("canvasReady", () => {
 	// Scene loaded.
 	for (let s of getSwarmingTokens()) {
 		createSwarmOnToken(s);
+	}
+});
+
+//Only in V10+
+Hooks.on("canvasTearDown", (a, b) => {
+	for (let key of Object.keys(SWARMS)) {
+		SWARMS[key].destroy();
+		delete SWARMS[key];
 	}
 });
 

--- a/script/swarm.mjs
+++ b/script/swarm.mjs
@@ -292,7 +292,7 @@ export default class Swarm {
         if(updateSprites) {
           const remaining = Math.round(this.maxSprites - this.visible);
           this.sprites.forEach((s,i) => {
-            s.alpha = i >= remaining ? this.spriteAlpha : 0;
+            s.alpha = i >= remaining ? this.spriteAlpha : this.faded && game.user.isGM ? this.spriteAlpha * 0.2: 0;
             this.scale = getScale(s);
             s.scale.x = this.scale.x;
             s.scale.y = this.scale.y;

--- a/script/swarm.mjs
+++ b/script/swarm.mjs
@@ -104,7 +104,7 @@ export default class Swarm {
 		this.sprites = [];
 		this.dest = [];
 		this.speeds = [];
-		this.ofsets = [];
+		this.offsets = [];
 		this.waiting = [];
 		this.layer = new PIXI.Container();
 
@@ -138,25 +138,25 @@ export default class Swarm {
 
 		this.tick = new PIXI.Ticker();
 		const anim = document.getFlag(MOD_NAME, ANIM_TYPE_FLAG);
-		this.set_destinations = this.circular;
+		this.setDestinations = this.circular;
 		switch (anim) {
 			case ANIM_TYPE_CIRCULAR:
-				this.set_destinations = this.circular;
+				this.setDestinations = this.circular;
 				break;
 			case ANIM_TYPE_RAND_SQUARE:
-				this.set_destinations = this.randSquare;
+				this.setDestinations = this.randSquare;
 				break;
 			case ANIM_TYPE_SPIRAL:
-				this.set_destinations = this.spiral;
+				this.setDestinations = this.spiral;
 				break;
 			case ANIM_TYPE_SKITTER:
-				this.set_destinations = this.skitter;
+				this.setDestinations = this.skitter;
 				break;
 			case ANIM_TYPE_STOPNMOVE:
-				this.set_destinations = this.stopMoveStop;
+				this.setDestinations = this.stopMoveStop;
 				break;
 			case ANIM_TYPE_FORMATION_SQUARE:
-				this.set_destinations = this.formSquare;
+				this.setDestinations = this.formSquare;
 				// this.randomRotation = false;
 				break;
 		}
@@ -181,7 +181,7 @@ export default class Swarm {
 			// waiting times, only used for stop-move
 			this.waiting.push(0);
 			// Random offset
-			this.ofsets.push(Math.random() * 97);
+			this.offsets.push(Math.random() * 97);
 			// Pick an image from the list at random
 			let img = images[Math.floor(Math.random() * images.length)];
 			let s = PIXI.Sprite.from(img);
@@ -241,6 +241,9 @@ export default class Swarm {
 	 * @param {Number} t Time fraction of the current fps
 	 */
 	anim(t) {
+		if (!this.token.width || !this.token.height) {
+			return;
+		}
 		if (!this.created) {
 			this.createSprites(this.maxSprites); // Use maxSprites instead of number
 		}
@@ -313,7 +316,7 @@ export default class Swarm {
 		}
 
 		// Calling the animation specific method, set_destination
-		this.set_destinations(ms);
+		this.setDestinations(ms);
 		// Calling the generic move method
 		this.move(ms);
 		this.created = true;
@@ -460,7 +463,7 @@ export default class Swarm {
 		let rx = 0.5 * this.token.w;
 		let ry = 0.5 * this.token.h;
 		for (let i = 0; i < this.sprites.length; ++i) {
-			let t = this.speeds[i] * this.t * 0.02 + this.ofsets[i];
+			let t = this.speeds[i] * this.t * 0.02 + this.offsets[i];
 			let x = Math.cos(t);
 			let y = 0.4 * Math.sin(t);
 
@@ -478,15 +481,15 @@ export default class Swarm {
 		let _ry = 1 * 0.5 * this.token.h;
 
 		for (let i = 0; i < this.sprites.length; ++i) {
-			let t = this.t * 0.02 + this.ofsets[i];
+			let t = this.t * 0.02 + this.offsets[i];
 			let rY =
 				1 *
 				(0.5 + 0.5 * (1.0 * Math.sin(t * 0.3) + 0.3 * Math.sin(2 * t + 0.8) + 0.26 * Math.sin(3 * t + 0.8)));
 			let x = Math.cos(t * this.speeds[i]);
 			let y = rY * Math.sin(t * this.speeds[i]);
 
-			let ci = Math.cos(this.ofsets[i]);
-			let si = Math.sin(this.ofsets[i]);
+			let ci = Math.cos(this.offsets[i]);
+			let si = Math.sin(this.offsets[i]);
 			let rx = _rx * (ci * x - si * y);
 			let ry = _ry * (si * x + ci * y);
 

--- a/script/swarm.mjs
+++ b/script/swarm.mjs
@@ -84,7 +84,7 @@ let SWARMS = {};
 // TODO: Remove debug accessor
 window.SWARMS = SWARMS;
 
-export default class Swarm{
+export default class Swarm {
     constructor( token, number ){
         this.t = 0;
         this.token  = token;
@@ -162,7 +162,7 @@ export default class Swarm{
             // Sprites initial position, a random position within this tokens area
             s.x = token.x + Math.random()*token.w;
             s.y = token.y + Math.random()*token.h;
-            // Hiden initially?
+            // Hidden initially?
             s.alpha = (hidden)?0:1;
 
             // A callback to get correct aspect ratio, and to start the video
@@ -506,11 +506,8 @@ Hooks.on('sightRefresh', (canvasVisibility) => {
   if(canvasVisibility.tokenVision) {
     const swarmedTokens = getSwarmingTokens();
     for(let t of swarmedTokens) {
-      if(t.isVisible && !SWARMS[t.id]) {
-        createSwarmOnToken(t);
-      } else if(!t.isVisible && SWARMS[t.id]) {
-        deleteSwarmOnToken(t);
-      }
+      const swarm = SWARMS[t.id];
+      swarm.layer.alpha = t.isVisible ? 1 : 0;
     }
   }
 })

--- a/script/swarm.mjs
+++ b/script/swarm.mjs
@@ -126,7 +126,7 @@ export default class Swarm {
 		});
 		token.alpha = 0;
 
-		this.layer.elevation = document.getFlag(MOD_NAME, OVER_FLAG) ? 10000 : 0;
+		this.layer.elevation = document.getFlag(MOD_NAME, OVER_FLAG) ? 10000 : document.elevation || 0;
 		this.layer.sort = 120; // Above tiles at 100
 		this.layer.alpha = token.isVisible ? this.spriteAlpha : 0;
 		canvas.primary.addChild(this.layer);
@@ -159,6 +159,7 @@ export default class Swarm {
 		}
 		this.tick.add(this.anim.bind(this));
 		this.tick.start();
+		this.token.refresh();
 		Hooks.call("createSwarm", this);
 	}
 

--- a/script/swarm.mjs
+++ b/script/swarm.mjs
@@ -105,6 +105,7 @@ export default class Swarm {
         
         this.layer.elevation = (token.document.getFlag(MOD_NAME, OVER_FLAG)?10000:0);
         this.layer.sort = 120; // Above tiles at 100
+        this.layer.alpha = token.isVisible ? 1 : 0;
         canvas.primary.addChild(this.layer);
                 
         this.created = false;

--- a/script/swarm.mjs
+++ b/script/swarm.mjs
@@ -214,7 +214,6 @@ export default class Swarm{
     anim(t){
         if (!this.created){
           this.createSprites(this.maxSprites, this.token, this.layer);  // Use maxSprites instead of number
-          this.created=true;
         }
 
         t = Math.min(t,2.0);// Cap frame skip to two frames
@@ -235,12 +234,13 @@ export default class Swarm{
             this.sprites.forEach((s,i)=>{s.alpha = (i>this.visible)?0:1});
         }
 
-        let currentHPPercent = this.calculateHPPercent();
-                if (currentHPPercent !== this.currentHPPercent) {
+        const currentHPPercent = this.calculateHPPercent();
+        if (currentHPPercent !== this.currentHPPercent || !this.created) {
             this.currentHPPercent = currentHPPercent;
             this.number = this.determineVisibleSprites(currentHPPercent, this.maxSprites);
             // Adjust visibility based on the number of "surviving" sprites
-            this.sprites.forEach((s, i) => {
+            // Start from last sprite as formations would move to the front.
+            this.sprites.toReversed().forEach((s, i) => {
                 s.alpha = (i < this.number) ? 1 : 0;
             });
         }
@@ -249,6 +249,7 @@ export default class Swarm{
         this.set_destinations(ms);
         // Calling the generic move method
         this.move(ms);
+        this.created = true;
         // Keep rotation
         // if (!this.randomRotation){
         //     this.rotation(this.token.document.rotation);

--- a/script/swarm.mjs
+++ b/script/swarm.mjs
@@ -31,6 +31,7 @@ const SETTING_HP_REDUCE_ATTRIBUTE_VALUE = "attributeHpValue";
 const SETTING_HP_REDUCE_ATTRIBUTE_MAX = "attributeHpMax";
 const SETTING_FADE_TIME = "fadeTime";
 const SETTING_STOP_TIME = "stopTime";
+const SETTING_MIGRATED_TO = "migratedTo";
 const theta = 0.01;
 const SIGMA = 5;
 const GAMMA = 1000;
@@ -80,14 +81,16 @@ function getHealthEstimate(token){
 }
 
  
-let SWARMS = {};
+const SWARMS = {};
 // TODO: Remove debug accessor
 window.SWARMS = SWARMS;
 
 export default class Swarm {
-    constructor( token, number ){
+    constructor( token, document = token.document ){
+        const number = document.getFlag(MOD_NAME, SWARM_SIZE_FLAG)
         this.t = 0;
-        this.token  = token;
+        this.token = token;
+        this.document = document
         this.currentHPPercent = this.calculateHPPercent();  // Calculate current HP percent
         this.number = this.determineVisibleSprites(this.currentHPPercent, number);  // Determine initial number of visible sprites
         this.maxSprites = number;  // Store the maximum number of sprites
@@ -99,20 +102,35 @@ export default class Swarm {
         this.layer = new PIXI.Container();
 
         // this.randomRotation = true;        
-        this.faded  = token.document.hidden;
-        this.visible= (this.faded)?0:this.number;
+        this.faded  = document.hidden;
+        this.visible= (this.faded) ? 0 : this.number;
+        this.spriteAlpha = document.alpha;
 
-        
-        this.layer.elevation = (token.document.getFlag(MOD_NAME, OVER_FLAG)?10000:0);
+        const swarm = this;
+
+        Object.defineProperty(document, "alpha", {
+          get() {
+            return 0;
+          },
+          set(v) {
+            if(!document.hidden) {
+              swarm.spriteAlpha = v
+            }
+          },
+          configurable: true,
+          enumerable: true,
+        });
+        token.alpha = 0;
+
+        this.layer.elevation = (document.getFlag(MOD_NAME, OVER_FLAG)?10000:0);
         this.layer.sort = 120; // Above tiles at 100
-        this.layer.alpha = token.isVisible ? 1 : 0;
+        this.layer.alpha = token.isVisible ? this.spriteAlpha : 0;
         canvas.primary.addChild(this.layer);
                 
         this.created = false;
-        //this.createSprites(number, token, this.layer);
         
         this.tick = new PIXI.Ticker();
-        let anim = token.document.getFlag(MOD_NAME, ANIM_TYPE_FLAG);
+        const anim = document.getFlag(MOD_NAME, ANIM_TYPE_FLAG);
         this.set_destinations = this.circular;
         switch(anim){
           case ANIM_TYPE_CIRCULAR:
@@ -137,17 +155,18 @@ export default class Swarm {
         }
         this.tick.add( this.anim.bind(this) );
         this.tick.start();
+        Hooks.call('createSwarm', this)
     }
     
-    async createSprites( number, token, layer ){
-        let use_random_image    = token.actor.prototypeToken.randomImg;
-        let hidden = token.document.hidden;
+    async createSprites( number ){
+        const use_random_image = this.token.actor.prototypeToken.randomImg;
+        const hidden = this.document.hidden;
 
-        let images = [];
+        const images = [];
         if (use_random_image){            
             images = await swarm_socket.executeAsGM("wildcards",token.id);                
         }else{
-          images.push(token.document.texture.src);
+          images.push(this.document.texture.src);
         }
 
         for(let i=0;i<number;++i){
@@ -161,38 +180,33 @@ export default class Swarm {
             s.anchor.set(.5);
             
             // Sprites initial position, a random position within this tokens area
-            s.x = token.x + Math.random()*token.w;
-            s.y = token.y + Math.random()*token.h;
+            s.x = this.token.x + Math.random() * this.token.w;
+            s.y = this.token.y + Math.random() * this.token.h;
             // Hidden initially?
             s.alpha = (hidden)?0:1;
 
-            // A callback to get correct aspect ratio, and to start the video
-            let scale = ()=>{              
-                // Get the largest dimention, and scale around that
-                let smax = Math.max(s.texture.width, s.texture.height);
-                s.scale.x = token.document.texture.scaleX * canvas.grid.size / smax;
-                s.scale.y = token.document.texture.scaleY * canvas.grid.size / smax;
-                
+            // A callback to start the video
+            const start = () => {       
                 // Check if the texture selected is a video, and potentially start it
-                let src = s.texture.baseTexture.resource.source;
+                const src = s.texture.baseTexture.resource.source;
                 src.loop = true;
                 src.muted = true; // Autostarting videos must explicitly be muted (chrome restriction)
                 if (src.play) src.play();
             };
             if (s.texture.baseTexture.valid){
-              scale();
-            }else{
-              s.texture.baseTexture.on('loaded', scale);
+              start();
+            } else {
+              s.texture.baseTexture.on('loaded', start);
             }            
             // Set the initial destination to its initial position
             this.dest.push({x:s.x, y:s.y});
             this.sprites.push(s);
-            let sf = token.document.getFlag(MOD_NAME, SWARM_SPEED_FLAG);
+            let sf = this.document.getFlag(MOD_NAME, SWARM_SPEED_FLAG);
             if (sf===undefined) sf = 1;
             // Add 50% of the speed as variability on each sprites speed
             this.speeds.push( sf*.5 + sf * Math.random()*0.5 )
             // Add this sprite to the correct layer
-            layer.addChild(s);
+            this.layer.addChild(s);
         }
     }
 
@@ -207,42 +221,85 @@ export default class Swarm {
         return Math.max(minSprites, Math.round(hpPercent * maxNumber));
     }
 
+    determineStep(ms) {
+      const fd = game.settings.get(MOD_NAME, SETTING_FADE_TIME);
+      const count = Math.abs(this.visible - this.number);
+      // step, corresponding to the module setting "fade time", also, prevent division by zero
+      return (fd==0)?(count):(ms*count)/(fd*1000);
+    }
+
     /**
      * The main animation callback for this swarm
      * @param {Number} t Time fraction of the current fps
      */
     anim(t){
         if (!this.created){
-          this.createSprites(this.maxSprites, this.token, this.layer);  // Use maxSprites instead of number
+          this.createSprites(this.maxSprites);  // Use maxSprites instead of number
         }
 
         t = Math.min(t,2.0);// Cap frame skip to two frames
         // Milliseconds elapsed, as calculated using the "time" fraction and current fps
-        let ms = t*1000*(1.0/this.tick.FPS);
-        let fd = game.settings.get(MOD_NAME, SETTING_FADE_TIME);
-        // step, corresponding to the module setting "fade time", also, prevent division by zero
-        let step = (fd==0)?(this.number):(ms*this.number)/(fd*1000);
+        const ms = t*1000*(1.0/this.tick.FPS);
+       
 
-        if (this.faded && (this.visible>0)){ 
-            // We should be faded/hidden, and we still have critters visible
-            this.visible -= step;
-            this.sprites.forEach((s,i)=>{s.alpha = (i>=this.visible)?0:1});
+        const getScale = s => {
+          // Get the largest dimension, and scale around that
+          const smax = Math.max(s.texture.width, s.texture.height);
+          const x = this.document.texture.scaleX * canvas.grid.size / smax;
+          const y = this.document.texture.scaleY * canvas.grid.size / smax;
+          return {x, y}
         }
-        if (!this.faded && (this.visible<this.number)){ 
-            // We should be visible, and we still have critters hidden
-            this.visible += step;
-            this.sprites.forEach((s,i)=>{s.alpha = (i>this.visible)?0:1});
-        }
+
+        let updateSprites =
+          this.tint != this.document.texture.tint;
 
         const currentHPPercent = this.calculateHPPercent();
         if (currentHPPercent !== this.currentHPPercent || !this.created) {
-            this.currentHPPercent = currentHPPercent;
-            this.number = this.determineVisibleSprites(currentHPPercent, this.maxSprites);
-            // Adjust visibility based on the number of "surviving" sprites
-            // Start from last sprite as formations would move to the front.
-            this.sprites.toReversed().forEach((s, i) => {
-                s.alpha = (i < this.number) ? 1 : 0;
-            });
+          this.currentHPPercent = currentHPPercent;
+          this.number = this.determineVisibleSprites(currentHPPercent, this.maxSprites);
+          this.step = this.determineStep(ms)
+          updateSprites = true;
+        }
+
+        if(this.step === null) {
+          this.step = this.determineStep(ms)
+        }
+
+        if (Math.round(this.visible) !== this.number) {
+          updateSprites = true;
+          if (this.visible > this.number) {
+            this.visible -= this.step;
+            if (this.visible < this.number) {
+              this.visible = this.number;
+            }
+          } else {
+            this.visible += this.step;
+            if (this.visible > this.number) {
+              this.visible = this.number;
+            }
+          }
+        }
+
+        if(!updateSprites && this.sprites.length) {
+          if (typeof this.scale === 'undefined') {
+            updateSprites = true;
+          } else {
+            const scale = getScale(this.sprites[0]);
+            updateSprites = this.scale.x !== scale.x || this.scale.y !== scale.y;
+          }
+        }
+
+        if(updateSprites) {
+          const remaining = Math.round(this.maxSprites - this.visible);
+          this.sprites.forEach((s,i) => {
+            s.alpha = i >= remaining ? this.spriteAlpha : 0;
+            this.scale = getScale(s);
+            s.scale.x = this.scale.x;
+            s.scale.y = this.scale.y;
+            if(this.document.texture.tint) {
+              this.tint = s.tint = this.document.texture.tint;
+            }
+          });
         }
 
         // Calling the animation specific method, set_destination
@@ -258,6 +315,13 @@ export default class Swarm {
 
     hide(hidden){
         this.faded = hidden;
+        // Clear step to be recalcuated on next tick
+        this.step = null;
+        if(hidden) {
+          this.number = 0;
+        } else {
+          this.number = this.determineVisibleSprites(this.currentHPPercent, this.maxSprites)
+        }
     }
 
     // TODO: HP interaction    
@@ -265,11 +329,19 @@ export default class Swarm {
     }
       
     destroy(){
+        Hooks.call('preDestroySwarm', this)
         for (let s of this.sprites){
             s.destroy();
         }
         this.tick.destroy();        
         this.layer.destroy();
+        Object.defineProperty(this.document, 'alpha', {
+          value: this.spriteAlpha, 
+          configurable: true,
+          enumerable: true,
+          writable: true
+        })
+        Hooks.call('destroySwarm', this)
     }
 
     skitter(ms) {
@@ -432,52 +504,100 @@ Hooks.on('canvasTearDown', (a,b)=>{
 });
 
 function deleteSwarmOnToken(token){
-    if (token.id in SWARMS){
-        SWARMS[token.id].destroy();
+  const swarm = SWARMS[token.id]
+    if (swarm){
+        swarm.destroy();
         delete SWARMS[token.id];
     }
 }
-function createSwarmOnToken(token){
-  SWARMS[token.id] = new Swarm(token, token.document.getFlag(MOD_NAME, SWARM_SIZE_FLAG));
-  if (!game.user.isGM){
-    token.alpha = 0;
-  }
+
+function createSwarmOnToken(token, document){
+  deleteSwarmOnToken(token);
+  Hooks.call('preCreateSwarm', token, document)
+  SWARMS[token.id] = new Swarm(token, document);
 }
+
 function hideSwarmOnToken(token, hide){
     if (token.id in SWARMS){
         SWARMS[token.id].hide(hide);
     }
 }
 
+/**
+ * @param {*} changes 
+ * @returns If any swarm related flag was in this update
+ */
+const swarmNeedsRefresh = changes => {
+  if(!changes) {
+    return false;
+  }
+  if (changes.flags?.[MOD_NAME]) {
+    return true;
+  }
+  if (typeof changes.alpha === "number") {
+    return true;
+  }
+  if (changes.texture) {
+    return true;
+  }
+  return false;
+}
 
+Hooks.on('preUpdateToken', (document, changes) => {
+  if (swarmNeedsRefresh(changes)) {   
+    deleteSwarmOnToken(document);
+  }
+})
 
-Hooks.on('updateToken', (token, change, options, user_id)=>{
-    if (change?.flags?.swarm){   // If any swarm related flag was in this update
+Hooks.on('updateToken', (document, changes) => {
+    if(document.flags?.[MOD_NAME]?.[SWARM_FLAG]) {
+      // if (swarmNeedsRefresh(changes)) {
+      //     createSwarmOnToken(canvas.tokens.get(document.id));
+      // }
+      if (changes.hidden != undefined){
+          hideSwarmOnToken(document, changes.hidden);
+      }
+    }
+});
+
+Hooks.on('renderTokenConfig', (renderConfig) => {
+  const document = renderConfig.token;
+  const onDrawToken = (token) => {
+    if(token.document.id === document.id) {
+      deleteSwarmOnToken(token);
+      if(token.document.flags?.[MOD_NAME]?.[SWARM_FLAG]) {
+          createSwarmOnToken(token);
+      }
+    }
+  }
+  Hooks.on('drawToken', onDrawToken)
+  Hooks.once('closeTokenConfig', (closeConfig) => {
+    if(closeConfig.token.id === document.id) {
+      Hooks.off('drawToken', onDrawToken);
+      const {token: document} = closeConfig;
+      const token = document.object;
+      if(token) {
         deleteSwarmOnToken(token);
-        if (token.flags?.[MOD_NAME]?.[SWARM_FLAG]){
-            createSwarmOnToken(canvas.tokens.get(token.id));
+        if(document.flags?.[MOD_NAME]?.[SWARM_FLAG]) {
+            createSwarmOnToken(token, document);
         }
+      }
     }
-
-    if (change.hidden != undefined && token.flags?.[MOD_NAME]?.[SWARM_FLAG]){
-        hideSwarmOnToken(token, change.hidden);
-    }
-    
+  })
 });
 
-
-// TODO: Add HP interaction
-Hooks.on('updateActor', (actor, change, options, user_id)=>{
-    let val = change.data?.attributes?.hp?.value;
-    if (val == undefined){
-        val = change.system?.attributes?.hp?.value;
-    }
-    if (val != undefined){
-      let tk = actor.token;
-      let mx = actor.data.data.attributes.hp.max;
-      let hp = 100*val/mx;
-    }
-});
+// // TODO: Add HP interaction
+// Hooks.on('updateActor', (actor, change, options, user_id)=>{
+//     let val = change.data?.attributes?.hp?.value;
+//     if (val == undefined){
+//         val = change.system?.attributes?.hp?.value;
+//     }
+//     if (val != undefined){
+//       let tk = actor.token;
+//       let mx = actor.data.data.attributes.hp.max;
+//       let hp = 100*val/mx;
+//     }
+// });
 
 
 // Delete token
@@ -487,17 +607,35 @@ Hooks.on('deleteToken', (token, options, user_id)=>{
     delete SWARMS[token.id];
   }
 })
+
+const isSwarmingToken = (t) =>!!t.document.getFlag(MOD_NAME,SWARM_FLAG);
+const getSwarmingTokens = () => canvas.tokens.placeables.filter(isSwarmingToken);
+
 // Create token
 Hooks.on('createToken', (token, options, user_id)=>{
-  //console.warn("Create Token", token, options);
   if (token.getFlag(MOD_NAME, SWARM_FLAG)===true){
     createSwarmOnToken(token.object);
   }
 });
 
-const getSwarmingTokens = () => canvas.tokens.placeables.filter((t)=>!!t.document.getFlag(MOD_NAME,SWARM_FLAG)) 
- 
-Hooks.on("canvasReady", ()=> {
+Hooks.on("ready", async () => {
+    if(game.settings.get(MOD_NAME, SETTING_MIGRATED_TO) < 11.0) {
+     ui.notifications.notify(`Migrating to Swarms version 11.  Please don't refresh your browser.`)
+     const actors = game.actors.filter(a => a.prototypeToken.getFlag(MOD_NAME, SWARM_FLAG) && a.prototypeToken.alpha === 0);
+     if(actors.length) {
+        await Promise.all(actors.map(async actor => await actor.prototypeToken.update({alpha: 1})))
+     }
+     let tokenCount = 0;
+     await Promise.all(game.scenes.map(async scene => {
+        const tokens = scene.tokens.filter(token => token.getFlag(MOD_NAME, SWARM_FLAG) && token.alpha === 0)
+        if(tokens.length) {
+          await Promise.all(tokens.map( async token => await token.update({alpha: 1})))
+          tokenCount += tokens.length;
+        }
+     }))
+     await game.settings.set(MOD_NAME, SETTING_MIGRATED_TO, 11.0);
+     ui.notifications.notify(`Migration to Swarms version 11 complete. Updated ${actors.length} actor(s) and ${tokenCount} token(s).`);
+    }
     // Scene loaded.
     for (let s of getSwarmingTokens()){
         createSwarmOnToken(s);
@@ -509,14 +647,15 @@ Hooks.on('sightRefresh', (canvasVisibility) => {
     const swarmedTokens = getSwarmingTokens();
     for(let t of swarmedTokens) {
       const swarm = SWARMS[t.id];
-      swarm.layer.alpha = t.isVisible ? 1 : 0;
+      if(swarm) { // Swarm might not exist if just been updated
+        swarm.layer.alpha = t.isVisible ? swarm.spriteAlpha : 0;
+      }
     }
   }
 })
  
  // Settings:
  Hooks.once("init", () => {
-  
     game.settings.register(MOD_NAME, SETTING_HP_REDUCE, {
         name: "Reduce swarm with HP",
         hint: "Reduce the swarm as HP decreases, requires support for your system",
@@ -558,9 +697,15 @@ Hooks.on('sightRefresh', (canvasVisibility) => {
       default: 5.0
   });
 
+  game.settings.register(MOD_NAME, SETTING_MIGRATED_TO, {
+      name: "Migrations",
+      scope: 'world',
+      config: false,
+      type: Number,
+      default: 0
+  });
   
  });
- 
 
 
  /*

--- a/script/utils.mjs
+++ b/script/utils.mjs
@@ -11,316 +11,321 @@
  ░                 ░              
  */
 
- /**
-  * @typedef {Object} Vec2
-  * @property {Number} x
-  * @property {Number} y
-  */
+/**
+ * @typedef {Object} Vec2
+ * @property {Number} x
+ * @property {Number} y
+ */
 
 /**
  * @param {*} value prepended value
- * @param {Array} array 
+ * @param {Array} array
  * @returns {Array} new array with value prepended
  */
- export function prepend(value, array) {
-    var newArray = array.slice();
-    newArray.unshift(value);
-    return newArray;
+export function prepend(value, array) {
+	var newArray = array.slice();
+	newArray.unshift(value);
+	return newArray;
 }
 
 /**
  * Negate a vector
- * @param {Vec2} p 
+ * @param {Vec2} p
  * @returns {Vec2}
  */
-export function vNeg(p){ // Return -1*v
-    return {x:-p.x, y:-p.y};
+export function vNeg(p) {
+	// Return -1*v
+	return { x: -p.x, y: -p.y };
 }
 /**
  * Add two vectors
- * @param {Vec2} p1 
- * @param {Vec2} p2 
+ * @param {Vec2} p1
+ * @param {Vec2} p2
  * @returns {Vec2}
  */
-export function vAdd(p1, p2){ // Return the sum, p1 + p2
-    return {x:p1.x+p2.x, y:p1.y+p2.y };
+export function vAdd(p1, p2) {
+	// Return the sum, p1 + p2
+	return { x: p1.x + p2.x, y: p1.y + p2.y };
 }
 /**
  * Subtract one vector from another
- * @param {Vec2} p1 
- * @param {Vec2} p2 
+ * @param {Vec2} p1
+ * @param {Vec2} p2
  * @returns {Vec2}
  */
-export function vSub(p1, p2){// Return the difference, p1-p2
-    return {x:p1.x-p2.x, y:p1.y-p2.y };
+export function vSub(p1, p2) {
+	// Return the difference, p1-p2
+	return { x: p1.x - p2.x, y: p1.y - p2.y };
 }
 /**
  * Multiply a vector, p, with a number, v
- * @param {Vec2} p 
- * @param {Number} v 
+ * @param {Vec2} p
+ * @param {Number} v
  * @returns {Vec2}
  */
-export function vMult(p,v){ // Multiply vector p with value v
-    return {x:p.x*v, y: p.y*v};  
+export function vMult(p, v) {
+	// Multiply vector p with value v
+	return { x: p.x * v, y: p.y * v };
 }
 /**
  * The dot product of two vectors.
- * @param {Vec2} p1 
- * @param {Vec2} p2 
+ * @param {Vec2} p1
+ * @param {Vec2} p2
  * @returns {Number}
  */
-export function vDot(p1, p2){ // Return the dot product of p1 and p2
-    return p1.x*p2.x + p1.y*p2.y;
+export function vDot(p1, p2) {
+	// Return the dot product of p1 and p2
+	return p1.x * p2.x + p1.y * p2.y;
 }
 /**
  * The length of a vector, p
- * @param {Vec2} p 
+ * @param {Vec2} p
  * @returns {Number}
  */
-export function vLen(p){ // Return the length of the vector p
-    return Math.sqrt(p.x**2 + p.y**2);
+export function vLen(p) {
+	// Return the length of the vector p
+	return Math.sqrt(p.x ** 2 + p.y ** 2);
 }
 /**
  * Returns the normalized vector of p
- * @param {Vec2} p 
+ * @param {Vec2} p
  * @returns {Vec2}
  */
-export function vNorm(p){ // Normalize the vector p, p/||p||
-    return vMult(p, 1.0/vLen(p));
+export function vNorm(p) {
+	// Normalize the vector p, p/||p||
+	return vMult(p, 1.0 / vLen(p));
 }
 /**
  * The angle matching the vector p
- * @param {Vec2} p 
+ * @param {Vec2} p
  * @returns {Number}
  */
-export function vAngle(p){ // The foundry compatible 'rotation angle' to point along the vector p
-    return 90+Math.toDegrees(Math.atan2(p.y, p.x));
+export function vAngle(p) {
+	// The foundry compatible 'rotation angle' to point along the vector p
+	return 90 + Math.toDegrees(Math.atan2(p.y, p.x));
 }
-export function vRad(p){ // The foundry compatible 'rotation angle' to point along the vector p
-    return Math.atan2(p.y, p.x);
-  }
-  
-
+export function vRad(p) {
+	// The foundry compatible 'rotation angle' to point along the vector p
+	return Math.atan2(p.y, p.x);
+}
 
 export class Vec2 {
-    constructor(x, y) {
-        this.x = x != null ? x : 0;
-        this.y = y != null ? y : 0;
-    }
-    set(x, y) {
-        this.x = x;
-        this.y = y;
-        return this;
-    }
-    setVec2(v) {
-        this.x = v.x;
-        this.y = v.y;
-        return this;
-    }
-    equals(v, tolerance) {
-        if (tolerance == null) {
-            tolerance = 0.0000001;
-        }
-        return (Math.abs(v.x - this.x) <= tolerance) && (Math.abs(v.y - this.y) <= tolerance);
-    }
-    add(v) {
-        this.x += v.x;
-        this.y += v.y;
-        return this;
-    }
-    added(v) {
-        return Vec2.create( this.x + v.x, this.y + v.y);        
-    }
-    sub(v) {
-        this.x -= v.x;
-        this.y -= v.y;
-        return this;
-    }
-    subbed(v) {
-        return Vec2.create( this.x - v.x, this.y - v.y);        
-    }
-    scale(f) {
-        this.x *= f;
-        this.y *= f;
-        return this;
-    }
-    scaled(f) {
-        return Vec2.create( this.x * f, this.y * f );
-    }
-    distance(v) {
-        var dx = v.x - this.x;
-        var dy = v.y - this.y;
-        return Math.sqrt(dx * dx + dy * dy);
-    }
-    squareDistance(v) {
-        var dx = v.x - this.x;
-        var dy = v.y - this.y;
-        return dx * dx + dy * dy;
-    }
-    copy(v) {
-        this.x = v.x;
-        this.y = v.y;
-        return this;
-    }
-    clone() {
-        return new Vec2(this.x, this.y);
-    }
-    dup(){
-        return this.clone();
-    }
-    dot(b) {
-        return this.x * b.x + this.y * b.y;
-    }
-    normalize() {
-        var len = this.length();
-        if (len > 0) {
-            this.scale(1 / len);
-        }
-        return this;
-    }
-    static create(x, y) {
-        return new Vec2(x, y);
-    }
-    static fromArray(a) {
-        return new Vec2(a[0], a[1]);
-    }
+	constructor(x, y) {
+		this.x = x != null ? x : 0;
+		this.y = y != null ? y : 0;
+	}
+	set(x, y) {
+		this.x = x;
+		this.y = y;
+		return this;
+	}
+	setVec2(v) {
+		this.x = v.x;
+		this.y = v.y;
+		return this;
+	}
+	equals(v, tolerance) {
+		if (tolerance == null) {
+			tolerance = 0.0000001;
+		}
+		return Math.abs(v.x - this.x) <= tolerance && Math.abs(v.y - this.y) <= tolerance;
+	}
+	add(v) {
+		this.x += v.x;
+		this.y += v.y;
+		return this;
+	}
+	added(v) {
+		return Vec2.create(this.x + v.x, this.y + v.y);
+	}
+	sub(v) {
+		this.x -= v.x;
+		this.y -= v.y;
+		return this;
+	}
+	subbed(v) {
+		return Vec2.create(this.x - v.x, this.y - v.y);
+	}
+	scale(f) {
+		this.x *= f;
+		this.y *= f;
+		return this;
+	}
+	scaled(f) {
+		return Vec2.create(this.x * f, this.y * f);
+	}
+	distance(v) {
+		var dx = v.x - this.x;
+		var dy = v.y - this.y;
+		return Math.sqrt(dx * dx + dy * dy);
+	}
+	squareDistance(v) {
+		var dx = v.x - this.x;
+		var dy = v.y - this.y;
+		return dx * dx + dy * dy;
+	}
+	copy(v) {
+		this.x = v.x;
+		this.y = v.y;
+		return this;
+	}
+	clone() {
+		return new Vec2(this.x, this.y);
+	}
+	dup() {
+		return this.clone();
+	}
+	dot(b) {
+		return this.x * b.x + this.y * b.y;
+	}
+	normalize() {
+		var len = this.length();
+		if (len > 0) {
+			this.scale(1 / len);
+		}
+		return this;
+	}
+	static create(x, y) {
+		return new Vec2(x, y);
+	}
+	static fromArray(a) {
+		return new Vec2(a[0], a[1]);
+	}
 }
 
-
 /**
- * 
+ *
  * @param {String} str String to test
  * @param {String} rule matching rule (e.g., something* )
  * @returns {Boolean}
  */
 function matchRuleShort(str, rule) {
-    var escapeRegex = (str) => str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
-    return new RegExp("^" + rule.split("*").map(escapeRegex).join(".*") + "$").test(str);
-  }
-
+	var escapeRegex = (str) => str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+	return new RegExp("^" + rule.split("*").map(escapeRegex).join(".*") + "$").test(str);
+}
 
 /**
  * @param {Array} arr1 Array to reorder
  * @param {Array} arr2 Array to sort, and used as indices for re-order array
  * @returns {Array} Array 1 sorted by array 2
  */
-export const dsu = (arr1, arr2) => arr1
-    .map((item, index) => [arr2[index], item]) // add the args to sort by
-    .sort(([arg1], [arg2]) => arg2 - arg1) // sort by the args
-    .map(([, item]) => item); // extract the sorted items
+export const dsu = (arr1, arr2) =>
+	arr1
+		.map((item, index) => [arr2[index], item]) // add the args to sort by
+		.sort(([arg1], [arg2]) => arg2 - arg1) // sort by the args
+		.map(([, item]) => item); // extract the sorted items
 
 export const argFact = (compareFn) => (array) => array.map((el, idx) => [el, idx]).reduce(compareFn)[1];
 export const argMax = argFact((min, el) => (el[0] > min[0] ? el : min));
 export const argMin = argFact((max, el) => (el[0] < max[0] ? el : max));
 
 /**
- * @param {Set} setA 
- * @param {Set} setB 
+ * @param {Set} setA
+ * @param {Set} setB
  * @returns {Set} Union of set A and B
  */
 export function setUnion(setA, setB) {
-    const union = new Set(setA);
-    for (const elem of setB) {
-        union.add(elem);
-    }
-    return union;
+	const union = new Set(setA);
+	for (const elem of setB) {
+		union.add(elem);
+	}
+	return union;
 }
 
-
 /**
- * @param {Set} setA 
- * @param {Set} setB 
+ * @param {Set} setA
+ * @param {Set} setB
  * @returns {Set} Union of set A and B
  */
 export function setDifference(setA, setB) {
-    let _difference = new Set(setA)
-    for (let elem of setB) {
-        _difference.delete(elem)
-    }
-    return _difference
+	let _difference = new Set(setA);
+	for (let elem of setB) {
+		_difference.delete(elem);
+	}
+	return _difference;
 }
 
 /**
- * @param {Set} setA 
- * @param {Set} setB 
+ * @param {Set} setA
+ * @param {Set} setB
  * @returns {Set} Intersection of set A and B
  */
 export function setIntersection(setA, setB) {
-    let _intersection = new Set()
-    for (let elem of setB) {
-        if (setA.has(elem)) {
-            _intersection.add(elem)
-        }
-    }
-    return _intersection
+	let _intersection = new Set();
+	for (let elem of setB) {
+		if (setA.has(elem)) {
+			_intersection.add(elem);
+		}
+	}
+	return _intersection;
 }
-
 
 // An implementation of hermite-like interpolation. The derivative is hermite-like, whereas the position is linearly interpolated
-export class SimpleSpline{
-    constructor(points, smoothness=0.0){
-      this.p = points;
-      this.smoothness = smoothness;
-      this.lengths = [];
-      for (let i = 1; i < this.len; ++i){
-        this.lengths.push( vLen(vSub(this.p[i-1], this.p[i])) );
-      }
-    }
-    parametricLength(){
-      return this.lengths.reduce((p, a)=>p+a,0);
-    }
-    get len (){
-      return this.p.length;
-    }
-    get plen(){
-      return this.parametricLength();
-    }
-  
-    // Position at parametric position t
-    parametricPosition( t ){
-      if (this.len<2){return this.p[0];}    
-      let len = 0;
-      for (let i = 1; i < this.len; ++i){
-        let nlen = this.lengths[i-1];
-        if (len+nlen >= t){
-          let nfrac = (t-len)/(nlen);//normalized fraction
-          // returning (1-nt)*prev + nt*cur
-          return vAdd(vMult(this.p[i-1], 1-nfrac), vMult(this.p[i], nfrac) );
-        }
-        len += nlen;
-      }
-      // we have gone past our parametric length, clamp at last point
-      return this.p[this.len-1];
-    }
-  
-    #iNorm(i){
-      if(i<1){
-        return vNorm(vSub(this.p[0], this.p[1]));
-      }
-      if(i > (this.len-2)){
-        // last (or past last) point, return (last - next to last)
-        return vNorm(vSub(this.p[this.len-2], this.p[this.len-1]));
-      }
-      return vNorm( vSub(this.p[i-1], this.p[i+1]));
-    }
-  
-    // Derivative at parametric position t
-    derivative(t){
-      if (t<=0){ 
-        return this.#iNorm(0);
-      }
-      let len = 0;
-      for (let i = 1; i < this.len; ++i){
-        let nlen = this.lengths[i-1];
-        if ((len+nlen) >= t){
-          let nfrac = (t-len)/(nlen);//normalized fraction
-          let p = this.#iNorm(i-1);
-          let n = this.#iNorm(i);
-          return vNorm( vAdd(vMult(p,1-nfrac), vMult(n,nfrac)) );
-        }
-        len += nlen;
-      }
-      return this.#iNorm(this.len);
-    }
+export class SimpleSpline {
+	constructor(points, smoothness = 0.0) {
+		this.p = points;
+		this.smoothness = smoothness;
+		this.lengths = [];
+		for (let i = 1; i < this.len; ++i) {
+			this.lengths.push(vLen(vSub(this.p[i - 1], this.p[i])));
+		}
+	}
+	parametricLength() {
+		return this.lengths.reduce((p, a) => p + a, 0);
+	}
+	get len() {
+		return this.p.length;
+	}
+	get plen() {
+		return this.parametricLength();
+	}
+
+	// Position at parametric position t
+	parametricPosition(t) {
+		if (this.len < 2) {
+			return this.p[0];
+		}
+		let len = 0;
+		for (let i = 1; i < this.len; ++i) {
+			let nlen = this.lengths[i - 1];
+			if (len + nlen >= t) {
+				let nfrac = (t - len) / nlen; //normalized fraction
+				// returning (1-nt)*prev + nt*cur
+				return vAdd(vMult(this.p[i - 1], 1 - nfrac), vMult(this.p[i], nfrac));
+			}
+			len += nlen;
+		}
+		// we have gone past our parametric length, clamp at last point
+		return this.p[this.len - 1];
+	}
+
+	#iNorm(i) {
+		if (i < 1) {
+			return vNorm(vSub(this.p[0], this.p[1]));
+		}
+		if (i > this.len - 2) {
+			// last (or past last) point, return (last - next to last)
+			return vNorm(vSub(this.p[this.len - 2], this.p[this.len - 1]));
+		}
+		return vNorm(vSub(this.p[i - 1], this.p[i + 1]));
+	}
+
+	// Derivative at parametric position t
+	derivative(t) {
+		if (t <= 0) {
+			return this.#iNorm(0);
+		}
+		let len = 0;
+		for (let i = 1; i < this.len; ++i) {
+			let nlen = this.lengths[i - 1];
+			if (len + nlen >= t) {
+				let nfrac = (t - len) / nlen; //normalized fraction
+				let p = this.#iNorm(i - 1);
+				let n = this.#iNorm(i);
+				return vNorm(vAdd(vMult(p, 1 - nfrac), vMult(n, nfrac)));
+			}
+			len += nlen;
+		}
+		return this.#iNorm(this.len);
+	}
 }
-  


### PR DESCRIPTION
@oOve as I've not heard back from you about potentially taking over the module, I'm just going to put this PR here.  It contains changes from pull #29 and #31 as well as changes to not have to set the opacity of the main token to 0 to hide it.  
Opacity and tint now are applied to the swarm.  There is a migration for existing swarms to reset their alpha to 1.

There is also a fix to set swarm elevation to match token elevation.

Comments appreciated.
